### PR TITLE
Fix auto pick port didn't use the configure host

### DIFF
--- a/crates/debugger_ui/src/debugger_panel_item.rs
+++ b/crates/debugger_ui/src/debugger_panel_item.rs
@@ -437,7 +437,7 @@ impl Render for DebugPanelItem {
                 h_flex()
                     .gap_2()
                     .map(|this| {
-                        if self.current_thread_state().status == ThreadStatus::Running {
+                        if thread_status == ThreadStatus::Running {
                             this.child(
                                 IconButton::new("debug-pause", IconName::DebugPause)
                                     .on_click(


### PR DESCRIPTION
This PR fixes an issue when auto-detecting a port, before we did this always based on the localhost, and we did not look at the host that was configured inside the task.