### PR TITLE
Fix use correct request to stop thread

### DIFF
--- a/crates/dap/src/client.rs
+++ b/crates/dap/src/client.rs
@@ -373,7 +373,6 @@ impl DebugAdapterClient {
         self.server_tx.send(Payload::Request(request)).await?;
 
         let response = callback_rx.recv().await??;
-        let _ = self.next_sequence_id();
 
         match response.success {
             true => Ok(serde_json::from_value(response.body.unwrap_or_default())?),

--- a/crates/dap/src/client.rs
+++ b/crates/dap/src/client.rs
@@ -4,13 +4,13 @@ use anyhow::{anyhow, Context, Result};
 use dap_types::{
     requests::{
         Attach, ConfigurationDone, Continue, Disconnect, Initialize, Launch, Next, Pause, Request,
-        Restart, SetBreakpoints, StepBack, StepIn, StepOut,
+        Restart, SetBreakpoints, StepBack, StepIn, StepOut, TerminateThreads,
     },
     AttachRequestArguments, ConfigurationDoneArguments, ContinueArguments, ContinueResponse,
     DisconnectArguments, InitializeRequestArgumentsPathFormat, LaunchRequestArguments,
     NextArguments, PauseArguments, RestartArguments, Scope, SetBreakpointsArguments,
     SetBreakpointsResponse, Source, SourceBreakpoint, StackFrame, StepBackArguments,
-    StepInArguments, StepOutArguments, SteppingGranularity, Variable,
+    StepInArguments, StepOutArguments, SteppingGranularity, TerminateThreadsArguments, Variable,
 };
 use futures::{AsyncBufRead, AsyncReadExt, AsyncWrite};
 use gpui::{AppContext, AsyncAppContext};
@@ -524,14 +524,13 @@ impl DebugAdapterClient {
             .log_err();
     }
 
-    pub async fn stop(&self) {
+    pub async fn stop(&self) -> Result<()> {
         self.request::<Disconnect>(DisconnectArguments {
             restart: Some(false),
             terminate_debuggee: Some(false),
             suspend_debuggee: Some(false),
         })
         .await
-        .log_err();
     }
 
     pub async fn set_breakpoints(
@@ -561,6 +560,11 @@ impl DebugAdapterClient {
 
     pub async fn configuration_done(&self) -> Result<()> {
         self.request::<ConfigurationDone>(ConfigurationDoneArguments)
+            .await
+    }
+
+    pub async fn terminate_threads(&self, thread_ids: Option<Vec<u64>>) -> Result<()> {
+        self.request::<TerminateThreads>(TerminateThreadsArguments { thread_ids })
             .await
     }
 }

--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -180,9 +180,6 @@ impl DebugPanel {
         event: &Events,
         cx: &mut ViewContext<Self>,
     ) {
-        // Increment the sequence id because an event is being processed
-        let _ = client.next_sequence_id();
-
         match event {
             Events::Initialized(event) => Self::handle_initialized_event(client, event, cx),
             Events::Stopped(event) => Self::handle_stopped_event(client, event, cx),

--- a/crates/task/src/lib.rs
+++ b/crates/task/src/lib.rs
@@ -14,8 +14,8 @@ use std::str::FromStr;
 use std::{borrow::Cow, path::Path};
 
 pub use task_template::{
-    DebugAdapterConfig, DebugConnectionType, DebugRequestType, RevealStrategy, TCPHost,
-    TaskTemplate, TaskTemplates, TaskType, HideStrategy,
+    DebugAdapterConfig, DebugConnectionType, DebugRequestType, HideStrategy, RevealStrategy,
+    TCPHost, TaskTemplate, TaskTemplates, TaskType,
 };
 pub use vscode_format::VsCodeTaskFile;
 


### PR DESCRIPTION
This PR fixes that we didn't send the correct request to stop a specific thread(s), which not all debuggers support. If they don't support terminating a one or more threads, we have to send the stop request.

I also removed the `next_sequence_id()` calls that we added by the breakpoints PR merge. This was not a valid assumption, because some debug adapters will not work anymore after this change.