### PR TITLE
Terminate thread when pane is closed/removed

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -169,8 +169,7 @@ pub enum Event {
     AddItem { item: Box<dyn ItemHandle> },
     ActivateItem { local: bool },
     Remove,
-    RemoveItem { idx: usize },
-    RemovedItem { item_id: EntityId },
+    RemovedItem { item: Box<dyn ItemHandle> },
     Split(SplitDirection),
     ChangeItemTitle,
     Focus,
@@ -190,10 +189,9 @@ impl fmt::Debug for Event {
                 .field("local", local)
                 .finish(),
             Event::Remove => f.write_str("Remove"),
-            Event::RemoveItem { idx } => f.debug_struct("RemoveItem").field("idx", idx).finish(),
-            Event::RemovedItem { item_id } => f
+            Event::RemovedItem { item } => f
                 .debug_struct("RemovedItem")
-                .field("item_id", item_id)
+                .field("item", &item.item_id())
                 .finish(),
             Event::Split(direction) => f
                 .debug_struct("Split")
@@ -1304,13 +1302,9 @@ impl Pane {
             }
         }
 
-        cx.emit(Event::RemoveItem { idx: item_index });
-
         let item = self.items.remove(item_index);
 
-        cx.emit(Event::RemovedItem {
-            item_id: item.item_id(),
-        });
+        cx.emit(Event::RemovedItem { item: item.clone() });
         if self.items.is_empty() {
             item.deactivated(cx);
             if close_pane_if_empty {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2904,11 +2904,10 @@ impl Workspace {
                 }
                 self.update_window_edited(cx);
             }
-            pane::Event::RemoveItem { .. } => {}
-            pane::Event::RemovedItem { item_id } => {
+            pane::Event::RemovedItem { item } => {
                 cx.emit(Event::ActiveItemChanged);
                 self.update_window_edited(cx);
-                if let hash_map::Entry::Occupied(entry) = self.panes_by_item.entry(*item_id) {
+                if let hash_map::Entry::Occupied(entry) = self.panes_by_item.entry(item.item_id()) {
                     if entry.get().entity_id() == pane.entity_id() {
                         entry.remove();
                     }


### PR DESCRIPTION
This PR changes my original idea how to fix send terminate threads a bit. Originally, my idea was to send a new event before we removed the pane, but It turns out that event is always received late. At that point, we cannot get the pane by his ID anymore. So to fix this I have to send the handle of the pane with the removed event so we can still grab some values from the pane in any subscriber.

https://github.com/user-attachments/assets/2e36a9b7-c2c8-4340-a8f4-926d23f322f6



/cc @Anthony-Eid