### PR TITLE
Always show disclosure icon for variables and scopes

### DIFF
--- a/crates/debugger_ui/src/debugger_panel_item.rs
+++ b/crates/debugger_ui/src/debugger_panel_item.rs
@@ -317,6 +317,7 @@ impl DebugPanelItem {
                 ListItem::new(scope_id.clone())
                     .indent_level(1)
                     .indent_step_size(px(20.))
+                    .always_show_disclosure_icon(false)
                     .toggle(disclosed)
                     .on_toggle(
                         cx.listener(move |this, _, cx| this.toggle_entry_collapsed(&scope_id, cx)),
@@ -346,6 +347,7 @@ impl DebugPanelItem {
                 ListItem::new(variable_id.clone())
                     .indent_level(depth + 1)
                     .indent_step_size(px(20.))
+                    .always_show_disclosure_icon(false)
                     .toggle(disclosed)
                     .on_toggle(
                         cx.listener(move |this, _, cx| {

--- a/crates/ui/src/components/list/list_item.rs
+++ b/crates/ui/src/components/list/list_item.rs
@@ -36,6 +36,7 @@ pub struct ListItem {
     on_secondary_mouse_down: Option<Box<dyn Fn(&MouseDownEvent, &mut WindowContext) + 'static>>,
     children: SmallVec<[AnyElement; 2]>,
     selectable: bool,
+    always_show_disclosure_icon: bool,
 }
 
 impl ListItem {
@@ -58,6 +59,7 @@ impl ListItem {
             tooltip: None,
             children: SmallVec::new(),
             selectable: true,
+            always_show_disclosure_icon: false,
         }
     }
 
@@ -68,6 +70,11 @@ impl ListItem {
 
     pub fn selectable(mut self, has_hover: bool) -> Self {
         self.selectable = has_hover;
+        self
+    }
+
+    pub fn always_show_disclosure_icon(mut self, show: bool) -> Self {
+        self.always_show_disclosure_icon = show;
         self
     }
 
@@ -230,7 +237,9 @@ impl RenderOnce for ListItem {
                             .flex()
                             .absolute()
                             .left(rems(-1.))
-                            .when(is_open, |this| this.visible_on_hover(""))
+                            .when(is_open && !self.always_show_disclosure_icon, |this| {
+                                this.visible_on_hover("")
+                            })
                             .child(Disclosure::new("toggle", is_open).on_toggle(self.on_toggle))
                     }))
                     .child(


### PR DESCRIPTION
/cc @Anthony-Eid 
/cc @Angelk90

## Before

https://github.com/user-attachments/assets/49b29f16-ec3a-42bb-8aa8-911e34ffe9c0


## After

https://github.com/user-attachments/assets/55f6ad62-a3a9-458b-aba6-9a87c63bafb1
