### PR TITLE
Lazy fetch variables

### DIFF
--- a/crates/dap/src/client.rs
+++ b/crates/dap/src/client.rs
@@ -55,6 +55,7 @@ pub struct DebugAdapterClientId(pub usize);
 pub struct ThreadState {
     pub status: ThreadStatus,
     pub stack_frames: Vec<StackFrame>,
+    // HashMap<variable_reference_id, Vec<Variable>>
     pub vars: HashMap<u64, Vec<Variable>>,
     // HashMap<stack_frame_id, <scope, Vec<(depth, Variable)>>>
     pub variables: HashMap<u64, BTreeMap<Scope, Vec<(usize, Variable)>>>,

--- a/crates/dap/src/client.rs
+++ b/crates/dap/src/client.rs
@@ -4,14 +4,14 @@ use anyhow::{anyhow, Context, Result};
 use dap_types::{
     requests::{
         Attach, ConfigurationDone, Continue, Disconnect, Initialize, Launch, Next, Pause, Request,
-        Restart, SetBreakpoints, StepBack, StepIn, StepOut, Terminate, TerminateThreads,
+        Restart, SetBreakpoints, StepBack, StepIn, StepOut, Terminate, TerminateThreads, Variables,
     },
     AttachRequestArguments, ConfigurationDoneArguments, ContinueArguments, ContinueResponse,
     DisconnectArguments, InitializeRequestArgumentsPathFormat, LaunchRequestArguments,
     NextArguments, PauseArguments, RestartArguments, Scope, SetBreakpointsArguments,
     SetBreakpointsResponse, Source, SourceBreakpoint, StackFrame, StepBackArguments,
     StepInArguments, StepOutArguments, SteppingGranularity, TerminateArguments,
-    TerminateThreadsArguments, Variable,
+    TerminateThreadsArguments, Variable, VariablesArguments,
 };
 use futures::{AsyncBufRead, AsyncReadExt, AsyncWrite};
 use gpui::{AppContext, AsyncAppContext};
@@ -55,6 +55,8 @@ pub struct DebugAdapterClientId(pub usize);
 pub struct ThreadState {
     pub status: ThreadStatus,
     pub stack_frames: Vec<StackFrame>,
+    pub vars: HashMap<u64, Vec<Variable>>,
+    // HashMap<stack_frame_id, <scope, Vec<(depth, Variable)>>>
     pub variables: HashMap<u64, BTreeMap<Scope, Vec<(usize, Variable)>>>,
     pub current_stack_frame_id: u64,
 }
@@ -702,6 +704,20 @@ impl DebugAdapterClient {
         } else {
             self.terminate().await
         }
+    }
+
+    pub async fn variables(&self, variables_reference: u64) -> Result<Vec<Variable>> {
+        anyhow::Ok(
+            self.request::<Variables>(VariablesArguments {
+                variables_reference,
+                filter: None,
+                start: None,
+                count: None,
+                format: None,
+            })
+            .await?
+            .variables,
+        )
     }
 }
 

--- a/crates/debugger_ui/src/debugger_panel_item.rs
+++ b/crates/debugger_ui/src/debugger_panel_item.rs
@@ -30,9 +30,6 @@ pub enum ThreadEntry {
         scope: Scope,
         variable: Arc<Variable>,
         has_children: bool,
-        // This is always none at the beginning,
-        // If you click on the variable we should fetch the nested first level variables
-        // task: Option<Task<Result<()>>>,
     },
 }
 
@@ -376,14 +373,14 @@ impl DebugPanelItem {
                             return this.toggle_entry_collapsed(&variable_id, cx);
                         }
 
-                        let mut entries = this.stack_frame_entries.clone();
-                        let Some(entries) =
-                            entries.get_mut(&this.current_thread_state().current_stack_frame_id)
+                        let Some(entries) = this
+                            .stack_frame_entries
+                            .get(&this.current_thread_state().current_stack_frame_id)
                         else {
                             return;
                         };
 
-                        let Some(entry) = entries.get_mut(ix) else {
+                        let Some(entry) = entries.get(ix) else {
                             return;
                         };
 


### PR DESCRIPTION
This fixes a memory leak when debugger python code. The python debug adapter sent infinite amount of nested variables back. Before this change, we did fetch all the variables when we received the stopped event, but since this is not supported for all the debug adapters. We have to implement lazy fetching variables by default.