### PR TITLE
Fix that debug tab was not showing anymore

### DIFF
--- a/crates/debugger_ui/src/debugger_panel_item.rs
+++ b/crates/debugger_ui/src/debugger_panel_item.rs
@@ -18,6 +18,10 @@ use workspace::dock::Panel;
 use workspace::item::{Item, ItemEvent};
 use workspace::Workspace;
 
+pub enum Event {
+    Close,
+}
+
 #[derive(PartialEq, Eq)]
 enum ThreadItem {
     Variables,
@@ -231,11 +235,11 @@ impl DebugPanelItem {
             return;
         }
 
-        cx.emit(ItemEvent::CloseItem);
+        cx.emit(Event::Close);
     }
 }
 
-impl EventEmitter<ItemEvent> for DebugPanelItem {}
+impl EventEmitter<Event> for DebugPanelItem {}
 
 impl FocusableView for DebugPanelItem {
     fn focus_handle(&self, _: &AppContext) -> FocusHandle {
@@ -244,7 +248,7 @@ impl FocusableView for DebugPanelItem {
 }
 
 impl Item for DebugPanelItem {
-    type Event = ItemEvent;
+    type Event = Event;
 
     fn tab_content(
         &self,
@@ -271,6 +275,12 @@ impl Item for DebugPanelItem {
             self.thread_id,
             self.current_thread_state().status
         )))
+    }
+
+    fn to_item_events(event: &Self::Event, mut f: impl FnMut(ItemEvent)) {
+        match event {
+            Event::Close => f(ItemEvent::CloseItem),
+        }
     }
 }
 

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -1544,19 +1544,15 @@ impl Project {
             return;
         };
 
+        cx.emit(Event::DebugClientStopped(client_id));
+
         if !should_terminate {
-            return cx.emit(Event::DebugClientStopped(client_id));
+            return;
         }
 
         if let DebugAdapterClientState::Running(client) = debug_client {
-            cx.spawn(|project, mut cx| async move {
-                client.terminate().await.log_err();
-
-                project.update(&mut cx, |_, cx| {
-                    cx.emit(Event::DebugClientStopped(client.id()))
-                })
-            })
-            .detach_and_log_err(cx)
+            cx.spawn(|_, _| async move { client.terminate().await })
+                .detach_and_log_err(cx)
         }
     }
 


### PR DESCRIPTION
This fixes an issue that was introduced in #20. The issue was that I only used the event to create a tab, but this does not actually add the tab to the pane. Not sure how I missed this while testing this feature, but closing the tab when debugger ends also works correctly now.