### PR TITLE
Remove duplicated content type code for debugger settings

### DIFF
--- a/crates/dap/src/debugger_settings.rs
+++ b/crates/dap/src/debugger_settings.rs
@@ -3,28 +3,32 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings::{Settings, SettingsSources};
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, JsonSchema, Clone, Copy)]
+#[serde(default)]
 pub struct DebuggerSettings {
-    pub save_breakpoints: bool,
-    pub button: bool,
-}
-
-#[derive(Default, Serialize, Deserialize, JsonSchema, Clone)]
-pub struct DebuggerSettingsContent {
     /// Whether the breakpoints should be reused across Zed sessions.
     ///
     /// Default: true
-    pub save_breakpoints: Option<bool>,
+    pub save_breakpoints: bool,
     /// Whether to show the debug button in the status bar.
     ///
     /// Default: true
-    pub button: Option<bool>,
+    pub button: bool,
+}
+
+impl Default for DebuggerSettings {
+    fn default() -> Self {
+        Self {
+            button: true,
+            save_breakpoints: true,
+        }
+    }
 }
 
 impl Settings for DebuggerSettings {
     const KEY: Option<&'static str> = Some("debugger");
 
-    type FileContent = DebuggerSettingsContent;
+    type FileContent = Self;
 
     fn load(
         sources: SettingsSources<Self::FileContent>,


### PR DESCRIPTION
Refactored this because its being refactored inside: https://github.com/zed-industries/zed/pull/16744