### PR TITLE
Refactor: move types to the correct place and move specific request code to dapstore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3346,7 +3346,7 @@ dependencies = [
 [[package]]
 name = "dap-types"
 version = "0.0.1"
-source = "git+https://github.com/zed-industries/dap-types#d4e23edcf7c8ded91a3bdfd32a216bcab68b710c"
+source = "git+https://github.com/zed-industries/dap-types#b7404edcd158d7d3ed8a7e81cf6cb3145ff3eb19"
 dependencies = [
  "serde",
  "serde_json",

--- a/crates/dap/src/adapters.rs
+++ b/crates/dap/src/adapters.rs
@@ -194,9 +194,9 @@ impl DebugAdapter for CustomDebugAdapter {
 
     async fn connect(&self, cx: &mut AsyncAppContext) -> Result<TransportParams> {
         match &self.connection {
-            DebugConnectionType::STDIO => create_stdio_client(&self.start_command, &vec![].into()),
+            DebugConnectionType::STDIO => create_stdio_client(&self.start_command, &vec![]),
             DebugConnectionType::TCP(tcp_host) => {
-                create_tcp_client(tcp_host.clone(), &self.start_command, &vec![].into(), cx).await
+                create_tcp_client(tcp_host.clone(), &self.start_command, &vec![], cx).await
             }
         }
     }

--- a/crates/dap/src/client.rs
+++ b/crates/dap/src/client.rs
@@ -5,8 +5,8 @@ use crate::adapters::{build_adapter, DebugAdapter};
 use dap_types::{
     messages::{Message, Response},
     requests::{Disconnect, Request, SetBreakpoints, Terminate, Variables},
-    DisconnectArguments, Scope, SetBreakpointsArguments, SetBreakpointsResponse, Source,
-    SourceBreakpoint, StackFrame, TerminateArguments, Variable, VariablesArguments,
+    DisconnectArguments, SetBreakpointsArguments, SetBreakpointsResponse, Source, SourceBreakpoint,
+    TerminateArguments, Variable, VariablesArguments,
 };
 use futures::{AsyncBufRead, AsyncWrite};
 use gpui::{AppContext, AsyncAppContext};
@@ -17,7 +17,6 @@ use smol::{
     process::Child,
 };
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
     hash::Hash,
     path::Path,
     sync::{
@@ -39,27 +38,6 @@ pub enum ThreadStatus {
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(transparent)]
 pub struct DebugAdapterClientId(pub usize);
-
-#[derive(Debug, Clone)]
-pub struct VariableContainer {
-    pub container_reference: u64,
-    pub variable: Variable,
-    pub depth: usize,
-}
-
-#[derive(Debug, Default, Clone)]
-pub struct ThreadState {
-    pub status: ThreadStatus,
-    pub stack_frames: Vec<StackFrame>,
-    /// HashMap<stack_frame_id, Vec<Scope>>
-    pub scopes: HashMap<u64, Vec<Scope>>,
-    /// BTreeMap<scope.variables_reference, Vec<VariableContainer>>
-    pub variables: BTreeMap<u64, Vec<VariableContainer>>,
-    pub fetched_variable_ids: HashSet<u64>,
-    // we update this value only once we stopped,
-    // we will use this to indicated if we should show a warning when debugger thread was exited
-    pub stopped: bool,
-}
 
 pub struct DebugAdapterClient {
     id: DebugAdapterClientId,

--- a/crates/dap/src/client.rs
+++ b/crates/dap/src/client.rs
@@ -4,9 +4,8 @@ use anyhow::{anyhow, Context, Result};
 use crate::adapters::{build_adapter, DebugAdapter};
 use dap_types::{
     messages::{Message, Response},
-    requests::{Disconnect, Request, SetBreakpoints, Terminate, Variables},
-    DisconnectArguments, SetBreakpointsArguments, SetBreakpointsResponse, Source, SourceBreakpoint,
-    TerminateArguments, Variable, VariablesArguments,
+    requests::{Disconnect, Request, Terminate, Variables},
+    DisconnectArguments, TerminateArguments, Variable, VariablesArguments,
 };
 use futures::{AsyncBufRead, AsyncWrite};
 use gpui::{AppContext, AsyncAppContext};
@@ -18,7 +17,6 @@ use smol::{
 };
 use std::{
     hash::Hash,
-    path::Path,
     sync::{
         atomic::{AtomicU64, Ordering},
         Arc,
@@ -207,29 +205,6 @@ impl DebugAdapterClient {
     /// Get the next sequence id to be used in a request
     pub fn next_sequence_id(&self) -> u64 {
         self.sequence_count.fetch_add(1, Ordering::Relaxed)
-    }
-
-    pub async fn set_breakpoints(
-        &self,
-        absolute_file_path: Arc<Path>,
-        breakpoints: Vec<SourceBreakpoint>,
-    ) -> Result<SetBreakpointsResponse> {
-        self.request::<SetBreakpoints>(SetBreakpointsArguments {
-            source: Source {
-                path: Some(String::from(absolute_file_path.to_string_lossy())),
-                name: None,
-                source_reference: None,
-                presentation_hint: None,
-                origin: None,
-                sources: None,
-                adapter_data: None,
-                checksums: None,
-            },
-            breakpoints: Some(breakpoints),
-            source_modified: None,
-            lines: None,
-        })
-        .await
     }
 
     pub async fn shutdown(&self) -> Result<()> {

--- a/crates/dap/src/client.rs
+++ b/crates/dap/src/client.rs
@@ -4,10 +4,9 @@ use anyhow::{anyhow, Context, Result};
 use crate::adapters::{build_adapter, DebugAdapter};
 use dap_types::{
     messages::{Message, Response},
-    requests::{Disconnect, Request, SetBreakpoints, StepBack, Terminate, Variables},
+    requests::{Disconnect, Request, SetBreakpoints, Terminate, Variables},
     DisconnectArguments, Scope, SetBreakpointsArguments, SetBreakpointsResponse, Source,
-    SourceBreakpoint, StackFrame, StepBackArguments, SteppingGranularity, TerminateArguments,
-    Variable, VariablesArguments,
+    SourceBreakpoint, StackFrame, TerminateArguments, Variable, VariablesArguments,
 };
 use futures::{AsyncBufRead, AsyncWrite};
 use gpui::{AppContext, AsyncAppContext};
@@ -230,25 +229,6 @@ impl DebugAdapterClient {
     /// Get the next sequence id to be used in a request
     pub fn next_sequence_id(&self) -> u64 {
         self.sequence_count.fetch_add(1, Ordering::Relaxed)
-    }
-
-    pub async fn step_back(&self, thread_id: u64, granularity: SteppingGranularity) -> Result<()> {
-        // TODO debugger: make this work again
-        let supports_single_thread_execution_requests = true;
-        // let supports_single_thread_execution_requests = capabilities
-        //     .supports_single_thread_execution_requests
-        //     .unwrap_or_default();
-        let supports_stepping_granularity = true;
-        // let supports_stepping_granularity = capabilities
-        //     .supports_stepping_granularity
-        //     .unwrap_or_default();
-
-        self.request::<StepBack>(StepBackArguments {
-            thread_id,
-            granularity: supports_stepping_granularity.then(|| granularity),
-            single_thread: supports_single_thread_execution_requests.then(|| true),
-        })
-        .await
     }
 
     pub async fn set_breakpoints(

--- a/crates/dap/src/client.rs
+++ b/crates/dap/src/client.rs
@@ -4,8 +4,8 @@ use anyhow::{anyhow, Context, Result};
 use crate::adapters::{build_adapter, DebugAdapter};
 use dap_types::{
     messages::{Message, Response},
-    requests::{Disconnect, Request, Terminate, Variables},
-    DisconnectArguments, TerminateArguments, Variable, VariablesArguments,
+    requests::{Disconnect, Request, Terminate},
+    DisconnectArguments, TerminateArguments,
 };
 use futures::{AsyncBufRead, AsyncWrite};
 use gpui::{AppContext, AsyncAppContext};
@@ -256,19 +256,5 @@ impl DebugAdapterClient {
             })
             .await
         }
-    }
-
-    pub async fn variables(&self, variables_reference: u64) -> Result<Vec<Variable>> {
-        anyhow::Ok(
-            self.request::<Variables>(VariablesArguments {
-                variables_reference,
-                filter: None,
-                start: None,
-                count: None,
-                format: None,
-            })
-            .await?
-            .variables,
-        )
     }
 }

--- a/crates/dap/src/client.rs
+++ b/crates/dap/src/client.rs
@@ -4,12 +4,10 @@ use anyhow::{anyhow, Context, Result};
 use crate::adapters::{build_adapter, DebugAdapter};
 use dap_types::{
     messages::{Message, Response},
-    requests::{
-        Disconnect, Request, SetBreakpoints, StepBack, StepIn, StepOut, Terminate, Variables,
-    },
+    requests::{Disconnect, Request, SetBreakpoints, StepBack, StepOut, Terminate, Variables},
     DisconnectArguments, Scope, SetBreakpointsArguments, SetBreakpointsResponse, Source,
-    SourceBreakpoint, StackFrame, StepBackArguments, StepInArguments, StepOutArguments,
-    SteppingGranularity, TerminateArguments, Variable, VariablesArguments,
+    SourceBreakpoint, StackFrame, StepBackArguments, StepOutArguments, SteppingGranularity,
+    TerminateArguments, Variable, VariablesArguments,
 };
 use futures::{AsyncBufRead, AsyncWrite};
 use gpui::{AppContext, AsyncAppContext};
@@ -232,26 +230,6 @@ impl DebugAdapterClient {
     /// Get the next sequence id to be used in a request
     pub fn next_sequence_id(&self) -> u64 {
         self.sequence_count.fetch_add(1, Ordering::Relaxed)
-    }
-
-    pub async fn step_in(&self, thread_id: u64, granularity: SteppingGranularity) -> Result<()> {
-        // TODO debugger: make this work again
-        let supports_single_thread_execution_requests = true;
-        // let supports_single_thread_execution_requests = capabilities
-        //     .supports_single_thread_execution_requests
-        //     .unwrap_or_default();
-        let supports_stepping_granularity = true;
-        // let supports_stepping_granularity = capabilities
-        //     .supports_stepping_granularity
-        //     .unwrap_or_default();
-
-        self.request::<StepIn>(StepInArguments {
-            thread_id,
-            target_id: None,
-            granularity: supports_stepping_granularity.then(|| granularity),
-            single_thread: supports_single_thread_execution_requests.then(|| true),
-        })
-        .await
     }
 
     pub async fn step_out(&self, thread_id: u64, granularity: SteppingGranularity) -> Result<()> {

--- a/crates/dap/src/client.rs
+++ b/crates/dap/src/client.rs
@@ -5,13 +5,11 @@ use crate::adapters::{build_adapter, DebugAdapter};
 use dap_types::{
     messages::{Message, Response},
     requests::{
-        Continue, Disconnect, Next, Request, SetBreakpoints, StepBack, StepIn, StepOut, Terminate,
-        Variables,
+        Disconnect, Next, Request, SetBreakpoints, StepBack, StepIn, StepOut, Terminate, Variables,
     },
-    ContinueArguments, ContinueResponse, DisconnectArguments, NextArguments, Scope,
-    SetBreakpointsArguments, SetBreakpointsResponse, Source, SourceBreakpoint, StackFrame,
-    StepBackArguments, StepInArguments, StepOutArguments, SteppingGranularity, TerminateArguments,
-    Variable, VariablesArguments,
+    DisconnectArguments, NextArguments, Scope, SetBreakpointsArguments, SetBreakpointsResponse,
+    Source, SourceBreakpoint, StackFrame, StepBackArguments, StepInArguments, StepOutArguments,
+    SteppingGranularity, TerminateArguments, Variable, VariablesArguments,
 };
 use futures::{AsyncBufRead, AsyncWrite};
 use gpui::{AppContext, AsyncAppContext};
@@ -234,21 +232,6 @@ impl DebugAdapterClient {
     /// Get the next sequence id to be used in a request
     pub fn next_sequence_id(&self) -> u64 {
         self.sequence_count.fetch_add(1, Ordering::Relaxed)
-    }
-
-    pub async fn resume(&self, thread_id: u64) -> Result<ContinueResponse> {
-        // TODO debugger: make this work again
-        let supports_single_thread_execution_requests = true;
-        // let supports_single_thread_execution_requests = self
-        //     .capabilities()
-        //     .supports_single_thread_execution_requests
-        //     .unwrap_or_default();
-
-        self.request::<Continue>(ContinueArguments {
-            thread_id,
-            single_thread: supports_single_thread_execution_requests.then(|| true),
-        })
-        .await
     }
 
     pub async fn step_over(&self, thread_id: u64, granularity: SteppingGranularity) -> Result<()> {

--- a/crates/dap/src/client.rs
+++ b/crates/dap/src/client.rs
@@ -4,10 +4,10 @@ use anyhow::{anyhow, Context, Result};
 use crate::adapters::{build_adapter, DebugAdapter};
 use dap_types::{
     messages::{Message, Response},
-    requests::{Disconnect, Request, SetBreakpoints, StepBack, StepOut, Terminate, Variables},
+    requests::{Disconnect, Request, SetBreakpoints, StepBack, Terminate, Variables},
     DisconnectArguments, Scope, SetBreakpointsArguments, SetBreakpointsResponse, Source,
-    SourceBreakpoint, StackFrame, StepBackArguments, StepOutArguments, SteppingGranularity,
-    TerminateArguments, Variable, VariablesArguments,
+    SourceBreakpoint, StackFrame, StepBackArguments, SteppingGranularity, TerminateArguments,
+    Variable, VariablesArguments,
 };
 use futures::{AsyncBufRead, AsyncWrite};
 use gpui::{AppContext, AsyncAppContext};
@@ -230,25 +230,6 @@ impl DebugAdapterClient {
     /// Get the next sequence id to be used in a request
     pub fn next_sequence_id(&self) -> u64 {
         self.sequence_count.fetch_add(1, Ordering::Relaxed)
-    }
-
-    pub async fn step_out(&self, thread_id: u64, granularity: SteppingGranularity) -> Result<()> {
-        // TODO debugger: make this work again
-        let supports_single_thread_execution_requests = true;
-        // let supports_single_thread_execution_requests = capabilities
-        //     .supports_single_thread_execution_requests
-        //     .unwrap_or_default();
-        let supports_stepping_granularity = true;
-        // let supports_stepping_granularity = capabilities
-        //     .supports_stepping_granularity
-        //     .unwrap_or_default();
-
-        self.request::<StepOut>(StepOutArguments {
-            thread_id,
-            granularity: supports_stepping_granularity.then(|| granularity),
-            single_thread: supports_single_thread_execution_requests.then(|| true),
-        })
-        .await
     }
 
     pub async fn step_back(&self, thread_id: u64, granularity: SteppingGranularity) -> Result<()> {

--- a/crates/dap/src/client.rs
+++ b/crates/dap/src/client.rs
@@ -6,13 +6,13 @@ use dap_types::{
     messages::{Message, Response},
     requests::{
         Attach, Continue, Disconnect, Launch, Next, Pause, Request, Restart, SetBreakpoints,
-        StepBack, StepIn, StepOut, Terminate, TerminateThreads, Variables,
+        StepBack, StepIn, StepOut, Terminate, Variables,
     },
     AttachRequestArguments, ContinueArguments, ContinueResponse, DisconnectArguments,
     LaunchRequestArguments, NextArguments, PauseArguments, RestartArguments, Scope,
     SetBreakpointsArguments, SetBreakpointsResponse, Source, SourceBreakpoint, StackFrame,
     StepBackArguments, StepInArguments, StepOutArguments, SteppingGranularity, TerminateArguments,
-    TerminateThreadsArguments, Variable, VariablesArguments,
+    Variable, VariablesArguments,
 };
 use futures::{AsyncBufRead, AsyncWrite};
 use gpui::{AppContext, AsyncAppContext};
@@ -467,20 +467,6 @@ impl DebugAdapterClient {
             .await
         } else {
             self.disconnect(None, Some(true), None).await
-        }
-    }
-
-    pub async fn terminate_threads(&self, thread_ids: Option<Vec<u64>>) -> Result<()> {
-        let support_terminate_threads = self
-            .capabilities()
-            .supports_terminate_threads_request
-            .unwrap_or_default();
-
-        if support_terminate_threads {
-            self.request::<TerminateThreads>(TerminateThreadsArguments { thread_ids })
-                .await
-        } else {
-            self.terminate().await
         }
     }
 

--- a/crates/dap/src/client.rs
+++ b/crates/dap/src/client.rs
@@ -371,38 +371,6 @@ impl DebugAdapterClient {
         self.request::<Pause>(PauseArguments { thread_id }).await
     }
 
-    pub async fn disconnect(
-        &self,
-        restart: Option<bool>,
-        terminate: Option<bool>,
-        suspend: Option<bool>,
-    ) -> Result<()> {
-        let supports_terminate_debuggee = self
-            .capabilities()
-            .support_terminate_debuggee
-            .unwrap_or_default();
-
-        let supports_suspend_debuggee = self
-            .capabilities()
-            .support_terminate_debuggee
-            .unwrap_or_default();
-
-        self.request::<Disconnect>(DisconnectArguments {
-            restart,
-            terminate_debuggee: if supports_terminate_debuggee {
-                terminate
-            } else {
-                None
-            },
-            suspend_debuggee: if supports_suspend_debuggee {
-                suspend
-            } else {
-                None
-            },
-        })
-        .await
-    }
-
     pub async fn set_breakpoints(
         &self,
         absolute_file_path: Arc<Path>,
@@ -466,7 +434,12 @@ impl DebugAdapterClient {
             })
             .await
         } else {
-            self.disconnect(None, Some(true), None).await
+            self.request::<Disconnect>(DisconnectArguments {
+                restart: Some(false),
+                terminate_debuggee: Some(true),
+                suspend_debuggee: Some(false),
+            })
+            .await
         }
     }
 

--- a/crates/dap/src/client.rs
+++ b/crates/dap/src/client.rs
@@ -5,14 +5,13 @@ use crate::adapters::{build_adapter, DebugAdapter};
 use dap_types::{
     messages::{Message, Response},
     requests::{
-        Attach, Continue, Disconnect, Launch, Next, Pause, Request, SetBreakpoints, StepBack,
-        StepIn, StepOut, Terminate, Variables,
+        Attach, Continue, Disconnect, Launch, Next, Request, SetBreakpoints, StepBack, StepIn,
+        StepOut, Terminate, Variables,
     },
     AttachRequestArguments, ContinueArguments, ContinueResponse, DisconnectArguments,
-    LaunchRequestArguments, NextArguments, PauseArguments, Scope, SetBreakpointsArguments,
-    SetBreakpointsResponse, Source, SourceBreakpoint, StackFrame, StepBackArguments,
-    StepInArguments, StepOutArguments, SteppingGranularity, TerminateArguments, Variable,
-    VariablesArguments,
+    LaunchRequestArguments, NextArguments, Scope, SetBreakpointsArguments, SetBreakpointsResponse,
+    Source, SourceBreakpoint, StackFrame, StepBackArguments, StepInArguments, StepOutArguments,
+    SteppingGranularity, TerminateArguments, Variable, VariablesArguments,
 };
 use futures::{AsyncBufRead, AsyncWrite};
 use gpui::{AppContext, AsyncAppContext};
@@ -358,10 +357,6 @@ impl DebugAdapterClient {
             single_thread: supports_single_thread_execution_requests.then(|| true),
         })
         .await
-    }
-
-    pub async fn pause(&self, thread_id: u64) -> Result<()> {
-        self.request::<Pause>(PauseArguments { thread_id }).await
     }
 
     pub async fn set_breakpoints(

--- a/crates/dap/src/client.rs
+++ b/crates/dap/src/client.rs
@@ -5,10 +5,10 @@ use crate::adapters::{build_adapter, DebugAdapter};
 use dap_types::{
     messages::{Message, Response},
     requests::{
-        Disconnect, Next, Request, SetBreakpoints, StepBack, StepIn, StepOut, Terminate, Variables,
+        Disconnect, Request, SetBreakpoints, StepBack, StepIn, StepOut, Terminate, Variables,
     },
-    DisconnectArguments, NextArguments, Scope, SetBreakpointsArguments, SetBreakpointsResponse,
-    Source, SourceBreakpoint, StackFrame, StepBackArguments, StepInArguments, StepOutArguments,
+    DisconnectArguments, Scope, SetBreakpointsArguments, SetBreakpointsResponse, Source,
+    SourceBreakpoint, StackFrame, StepBackArguments, StepInArguments, StepOutArguments,
     SteppingGranularity, TerminateArguments, Variable, VariablesArguments,
 };
 use futures::{AsyncBufRead, AsyncWrite};
@@ -232,25 +232,6 @@ impl DebugAdapterClient {
     /// Get the next sequence id to be used in a request
     pub fn next_sequence_id(&self) -> u64 {
         self.sequence_count.fetch_add(1, Ordering::Relaxed)
-    }
-
-    pub async fn step_over(&self, thread_id: u64, granularity: SteppingGranularity) -> Result<()> {
-        // TODO debugger: make this work again
-        let supports_single_thread_execution_requests = true;
-        // let supports_single_thread_execution_requests = capabilities
-        //     .supports_single_thread_execution_requests
-        //     .unwrap_or_default();
-        let supports_stepping_granularity = true;
-        // let supports_stepping_granularity = capabilities
-        //     .supports_stepping_granularity
-        //     .unwrap_or_default();
-
-        self.request::<Next>(NextArguments {
-            thread_id,
-            granularity: supports_stepping_granularity.then(|| granularity),
-            single_thread: supports_single_thread_execution_requests.then(|| true),
-        })
-        .await
     }
 
     pub async fn step_in(&self, thread_id: u64, granularity: SteppingGranularity) -> Result<()> {

--- a/crates/dap/src/client.rs
+++ b/crates/dap/src/client.rs
@@ -5,14 +5,14 @@ use crate::adapters::{build_adapter, DebugAdapter};
 use dap_types::{
     messages::{Message, Response},
     requests::{
-        Attach, Continue, Disconnect, Launch, Next, Pause, Request, Restart, SetBreakpoints,
-        StepBack, StepIn, StepOut, Terminate, Variables,
+        Attach, Continue, Disconnect, Launch, Next, Pause, Request, SetBreakpoints, StepBack,
+        StepIn, StepOut, Terminate, Variables,
     },
     AttachRequestArguments, ContinueArguments, ContinueResponse, DisconnectArguments,
-    LaunchRequestArguments, NextArguments, PauseArguments, RestartArguments, Scope,
-    SetBreakpointsArguments, SetBreakpointsResponse, Source, SourceBreakpoint, StackFrame,
-    StepBackArguments, StepInArguments, StepOutArguments, SteppingGranularity, TerminateArguments,
-    Variable, VariablesArguments,
+    LaunchRequestArguments, NextArguments, PauseArguments, Scope, SetBreakpointsArguments,
+    SetBreakpointsResponse, Source, SourceBreakpoint, StackFrame, StepBackArguments,
+    StepInArguments, StepOutArguments, SteppingGranularity, TerminateArguments, Variable,
+    VariablesArguments,
 };
 use futures::{AsyncBufRead, AsyncWrite};
 use gpui::{AppContext, AsyncAppContext};
@@ -356,13 +356,6 @@ impl DebugAdapterClient {
             thread_id,
             granularity: supports_stepping_granularity.then(|| granularity),
             single_thread: supports_single_thread_execution_requests.then(|| true),
-        })
-        .await
-    }
-
-    pub async fn restart(&self) -> Result<()> {
-        self.request::<Restart>(RestartArguments {
-            raw: self.adapter.request_args(),
         })
         .await
     }

--- a/crates/dap/src/client.rs
+++ b/crates/dap/src/client.rs
@@ -4,8 +4,7 @@ use anyhow::{anyhow, Context, Result};
 use crate::adapters::{build_adapter, DebugAdapter};
 use dap_types::{
     messages::{Message, Response},
-    requests::{Disconnect, Request, Terminate},
-    DisconnectArguments, TerminateArguments,
+    requests::Request,
 };
 use futures::{AsyncBufRead, AsyncWrite};
 use gpui::{AppContext, AsyncAppContext};
@@ -208,8 +207,6 @@ impl DebugAdapterClient {
     }
 
     pub async fn shutdown(&self) -> Result<()> {
-        let _ = self.terminate().await;
-
         self.transport.server_tx.close();
         self.transport.server_rx.close();
 
@@ -233,28 +230,5 @@ impl DebugAdapterClient {
             anyhow::Ok(())
         }
         .await
-    }
-
-    pub async fn terminate(&self) -> Result<()> {
-        // TODO debugger: make this work again
-        let support_terminate_request = true;
-        // let support_terminate_request = self
-        //     .capabilities()
-        //     .supports_terminate_request
-        //     .unwrap_or_default();
-
-        if support_terminate_request {
-            self.request::<Terminate>(TerminateArguments {
-                restart: Some(false),
-            })
-            .await
-        } else {
-            self.request::<Disconnect>(DisconnectArguments {
-                restart: Some(false),
-                terminate_debuggee: Some(true),
-                suspend_debuggee: Some(false),
-            })
-            .await
-        }
     }
 }

--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -122,6 +122,8 @@ impl DebugPanel {
 
                             this.thread_states
                                 .retain(|&(client_id_, _), _| client_id_ != *client_id);
+
+                            cx.notify();
                         }
                         _ => {}
                     }

--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -17,7 +17,7 @@ use gpui::{
 };
 use project::dap_store::DapStore;
 use settings::Settings;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::Arc;
 use task::DebugRequestType;

--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -119,6 +119,11 @@ impl DebugPanel {
                         }
                         project::Event::DebugClientStopped(client_id) => {
                             cx.emit(DebugPanelEvent::ClientStopped(*client_id));
+
+                            this.thread_states
+                                .retain(|&(client_id_, _), _| client_id_ != *client_id);
+
+                            cx.notify();
                         }
                         _ => {}
                     }

--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -459,6 +459,15 @@ impl DebugPanel {
             return;
         };
 
+        let Some(client_kind) = self
+            .dap_store
+            .read(cx)
+            .client_by_id(client_id)
+            .map(|c| c.config().kind)
+        else {
+            return; // this can never happen
+        };
+
         let client_id = *client_id;
 
         cx.spawn({
@@ -572,6 +581,7 @@ impl DebugPanel {
                                     this.dap_store.clone(),
                                     thread_state.clone(),
                                     &client_id,
+                                    &client_kind,
                                     thread_id,
                                     current_stack_frame.clone().id,
                                     cx,

--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -406,8 +406,7 @@ impl DebugPanel {
     ) {
         if let Some(capabilities) = capabilities {
             self.dap_store.update(cx, |store, cx| {
-                store.merge_capabilities_for_client(&client.id(), capabilities);
-                cx.notify();
+                store.merge_capabilities_for_client(&client.id(), capabilities, cx);
             });
         }
 

--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -210,7 +210,7 @@ impl DebugPanel {
                 let thread_panel = item.downcast::<DebugPanelItem>().unwrap();
 
                 let thread_id = thread_panel.read(cx).thread_id();
-                let client_id = thread_panel.read(cx).client().id();
+                let client_id = thread_panel.read(cx).client_id();
 
                 self.thread_states.remove(&(client_id, thread_id));
 
@@ -548,7 +548,7 @@ impl DebugPanel {
                         .any(|item| {
                             let item = item.read(cx);
 
-                            item.client().id() == client_id && item.thread_id() == thread_id
+                            item.client_id() == client_id && item.thread_id() == thread_id
                         });
 
                     if !existing_item {
@@ -559,7 +559,7 @@ impl DebugPanel {
                                     debug_panel,
                                     this.workspace.clone(),
                                     this.dap_store.clone(),
-                                    client.clone(),
+                                    client.id(),
                                     thread_id,
                                     current_stack_frame.clone().id,
                                     cx,
@@ -577,7 +577,7 @@ impl DebugPanel {
                     if let Some(item) = this.pane.read(cx).active_item() {
                         if let Some(pane) = item.downcast::<DebugPanelItem>() {
                             let pane = pane.read(cx);
-                            if pane.thread_id() == thread_id && pane.client().id() == client_id {
+                            if pane.thread_id() == thread_id && pane.client_id() == client_id {
                                 let workspace = this.workspace.clone();
                                 return cx.spawn(|_, cx| async move {
                                     Self::go_to_stack_frame(

--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -411,9 +411,9 @@ impl DebugPanel {
         }
 
         let send_breakpoints_task = self.workspace.update(cx, |workspace, cx| {
-            workspace.project().update(cx, |project, cx| {
-                project.send_breakpoints(client.clone(), cx)
-            })
+            workspace
+                .project()
+                .update(cx, |project, cx| project.send_breakpoints(&client_id, cx))
         });
 
         let configuration_done_task = self.dap_store.update(cx, |store, cx| {
@@ -422,7 +422,7 @@ impl DebugPanel {
 
         cx.background_executor()
             .spawn(async move {
-                send_breakpoints_task?.await?;
+                send_breakpoints_task?.await;
 
                 configuration_done_task.await
             })

--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -355,7 +355,7 @@ impl DebugPanel {
     ) {
         if let Some(capabilities) = capabilities {
             self.dap_store.update(cx, |store, _| {
-                store.merge_capabilities(&client.id(), capabilities);
+                store.merge_capabilities_for_client(&client.id(), capabilities);
             });
         }
 

--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -1,13 +1,13 @@
 use crate::debugger_panel_item::DebugPanelItem;
 use anyhow::Result;
 use dap::client::DebugAdapterClient;
-use dap::client::{DebugAdapterClientId, ThreadState, ThreadStatus, VariableContainer};
+use dap::client::{DebugAdapterClientId, ThreadStatus};
 use dap::debugger_settings::DebuggerSettings;
 use dap::messages::{Events, Message};
 use dap::requests::{Request, Scopes, StackTrace, StartDebugging};
 use dap::{
-    Capabilities, ContinuedEvent, ExitedEvent, OutputEvent, ScopesArguments, StackFrame,
-    StackTraceArguments, StoppedEvent, TerminatedEvent, ThreadEvent, ThreadEventReason,
+    Capabilities, ContinuedEvent, ExitedEvent, OutputEvent, Scope, ScopesArguments, StackFrame,
+    StackTraceArguments, StoppedEvent, TerminatedEvent, ThreadEvent, ThreadEventReason, Variable,
 };
 use editor::Editor;
 use futures::future::try_join_all;
@@ -17,7 +17,7 @@ use gpui::{
 };
 use project::dap_store::DapStore;
 use settings::Settings;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::Path;
 use std::sync::Arc;
 use std::u64;
@@ -39,6 +39,27 @@ pub enum DebugPanelEvent {
 }
 
 actions!(debug_panel, [ToggleFocus]);
+
+#[derive(Debug, Clone)]
+pub struct VariableContainer {
+    pub container_reference: u64,
+    pub variable: Variable,
+    pub depth: usize,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct ThreadState {
+    pub status: ThreadStatus,
+    pub stack_frames: Vec<StackFrame>,
+    /// HashMap<stack_frame_id, Vec<Scope>>
+    pub scopes: HashMap<u64, Vec<Scope>>,
+    /// BTreeMap<scope.variables_reference, Vec<VariableContainer>>
+    pub variables: BTreeMap<u64, Vec<VariableContainer>>,
+    pub fetched_variable_ids: HashSet<u64>,
+    // we update this value only once we stopped,
+    // we will use this to indicated if we should show a warning when debugger thread was exited
+    pub stopped: bool,
+}
 
 pub struct DebugPanel {
     size: Pixels,

--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -119,11 +119,6 @@ impl DebugPanel {
                         }
                         project::Event::DebugClientStopped(client_id) => {
                             cx.emit(DebugPanelEvent::ClientStopped(*client_id));
-
-                            this.thread_states
-                                .retain(|&(client_id_, _), _| client_id_ != *client_id);
-
-                            cx.notify();
                         }
                         _ => {}
                     }

--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -426,12 +426,13 @@ impl DebugPanel {
             store.send_configuration_done(&client.id(), cx)
         });
 
-        cx.spawn(|_, _| async move {
-            send_breakpoints_task?.await?;
+        cx.background_executor()
+            .spawn(async move {
+                send_breakpoints_task?.await?;
 
-            configuration_done_task.await
-        })
-        .detach_and_log_err(cx);
+                configuration_done_task.await
+            })
+            .detach_and_log_err(cx);
     }
 
     fn handle_continued_event(

--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -626,8 +626,6 @@ impl DebugPanel {
             // .detach_and_log_err(cx);
         }
 
-        cx.notify();
-
         cx.emit(DebugPanelEvent::Thread((*client_id, event.clone())));
     }
 

--- a/crates/debugger_ui/src/debugger_panel_item.rs
+++ b/crates/debugger_ui/src/debugger_panel_item.rs
@@ -1,10 +1,8 @@
 use crate::console::Console;
-use crate::debugger_panel::{DebugPanel, DebugPanelEvent};
+use crate::debugger_panel::{DebugPanel, DebugPanelEvent, ThreadState, VariableContainer};
 use crate::variable_list::VariableList;
 
-use dap::client::{
-    DebugAdapterClient, DebugAdapterClientId, ThreadState, ThreadStatus, VariableContainer,
-};
+use dap::client::{DebugAdapterClient, DebugAdapterClientId, ThreadStatus};
 use dap::debugger_settings::DebuggerSettings;
 use dap::{Capabilities, OutputEvent, OutputEventCategory, StackFrame, StoppedEvent, ThreadEvent};
 use editor::Editor;

--- a/crates/debugger_ui/src/debugger_panel_item.rs
+++ b/crates/debugger_ui/src/debugger_panel_item.rs
@@ -418,12 +418,10 @@ impl DebugPanelItem {
     }
 
     fn handle_continue_action(&mut self, cx: &mut ViewContext<Self>) {
-        let thread_id = self.thread_id;
-
         self.debug_panel.update(cx, |panel, cx| {
             panel.update_thread_state_status(
                 &self.client.id(),
-                Some(thread_id),
+                Some(self.thread_id),
                 ThreadStatus::Running,
                 None,
                 cx,
@@ -432,18 +430,16 @@ impl DebugPanelItem {
 
         self.dap_store.update(cx, |store, cx| {
             store
-                .continue_thread(&self.client.id(), thread_id, cx)
+                .continue_thread(&self.client.id(), self.thread_id, cx)
                 .detach_and_log_err(cx);
         });
     }
 
     fn handle_step_over_action(&mut self, cx: &mut ViewContext<Self>) {
-        let thread_id = self.thread_id;
-
         self.debug_panel.update(cx, |panel, cx| {
             panel.update_thread_state_status(
                 &self.client.id(),
-                Some(thread_id),
+                Some(self.thread_id),
                 ThreadStatus::Running,
                 None,
                 cx,
@@ -454,19 +450,16 @@ impl DebugPanelItem {
 
         self.dap_store.update(cx, |store, cx| {
             store
-                .step_over(&self.client.id(), thread_id, granularity, cx)
+                .step_over(&self.client.id(), self.thread_id, granularity, cx)
                 .detach_and_log_err(cx);
         });
     }
 
     fn handle_step_in_action(&mut self, cx: &mut ViewContext<Self>) {
-        let client = self.client.clone();
-        let thread_id = self.thread_id;
-
         self.debug_panel.update(cx, |panel, cx| {
             panel.update_thread_state_status(
                 &self.client.id(),
-                Some(thread_id),
+                Some(self.thread_id),
                 ThreadStatus::Running,
                 None,
                 cx,
@@ -477,19 +470,16 @@ impl DebugPanelItem {
 
         self.dap_store.update(cx, |store, cx| {
             store
-                .step_in(&self.client.id(), thread_id, granularity, cx)
+                .step_in(&self.client.id(), self.thread_id, granularity, cx)
                 .detach_and_log_err(cx);
         });
     }
 
     fn handle_step_out_action(&mut self, cx: &mut ViewContext<Self>) {
-        let client = self.client.clone();
-        let thread_id = self.thread_id;
-
         self.debug_panel.update(cx, |panel, cx| {
             panel.update_thread_state_status(
                 &self.client.id(),
-                Some(thread_id),
+                Some(self.thread_id),
                 ThreadStatus::Running,
                 None,
                 cx,
@@ -498,9 +488,11 @@ impl DebugPanelItem {
 
         let granularity = DebuggerSettings::get_global(cx).stepping_granularity();
 
-        cx.background_executor()
-            .spawn(async move { client.step_out(thread_id, granularity).await })
-            .detach_and_log_err(cx);
+        self.dap_store.update(cx, |store, cx| {
+            store
+                .step_out(&self.client.id(), self.thread_id, granularity, cx)
+                .detach_and_log_err(cx);
+        });
     }
 
     fn handle_restart_action(&mut self, cx: &mut ViewContext<Self>) {

--- a/crates/debugger_ui/src/debugger_panel_item.rs
+++ b/crates/debugger_ui/src/debugger_panel_item.rs
@@ -78,7 +78,7 @@ impl DebugPanelItem {
         workspace: WeakView<Workspace>,
         dap_store: Model<DapStore>,
         thread_state: Model<ThreadState>,
-        client_id: DebugAdapterClientId,
+        client_id: &DebugAdapterClientId,
         thread_id: u64,
         current_stack_frame_id: u64,
         cx: &mut ViewContext<Self>,
@@ -146,7 +146,6 @@ impl DebugPanelItem {
 
         Self {
             console,
-            client_id,
             thread_id,
             dap_store,
             workspace,
@@ -157,6 +156,7 @@ impl DebugPanelItem {
             variable_list,
             _subscriptions,
             stack_frame_list,
+            client_id: *client_id,
             current_stack_frame_id,
             active_thread_item: ThreadItem::Variables,
         }

--- a/crates/debugger_ui/src/debugger_panel_item.rs
+++ b/crates/debugger_ui/src/debugger_panel_item.rs
@@ -182,7 +182,7 @@ impl DebugPanelItem {
             return;
         }
 
-        // TODO: handle thread event
+        // TODO debugger: handle thread event
     }
 
     fn handle_output_event(

--- a/crates/debugger_ui/src/debugger_panel_item.rs
+++ b/crates/debugger_ui/src/debugger_panel_item.rs
@@ -298,9 +298,8 @@ impl DebugPanelItem {
         self.current_stack_frame_id = stack_frame_id;
 
         self.variable_list.update(cx, |variable_list, cx| {
+            variable_list.update_stack_frame_id(stack_frame_id, cx);
             variable_list.build_entries(stack_frame_id, true, false, cx);
-
-            cx.notify();
         });
 
         cx.notify();

--- a/crates/debugger_ui/src/debugger_panel_item.rs
+++ b/crates/debugger_ui/src/debugger_panel_item.rs
@@ -251,6 +251,10 @@ impl DebugPanelItem {
             return;
         }
 
+        this.stack_frame_list.reset(0);
+
+        cx.notify();
+
         cx.emit(Event::Close);
     }
 

--- a/crates/debugger_ui/src/debugger_panel_item.rs
+++ b/crates/debugger_ui/src/debugger_panel_item.rs
@@ -158,7 +158,7 @@ impl DebugPanelItem {
         event: &StoppedEvent,
         cx: &mut ViewContext<Self>,
     ) {
-        if Self::should_skip_event(this, client_id, event.thread_id.unwrap_or_default()) {
+        if Self::should_skip_event(this, client_id, event.thread_id.unwrap_or(this.thread_id)) {
             return;
         }
 

--- a/crates/debugger_ui/src/debugger_panel_item.rs
+++ b/crates/debugger_ui/src/debugger_panel_item.rs
@@ -553,7 +553,8 @@ impl Item for DebugPanelItem {
     ) -> AnyElement {
         Label::new(format!(
             "{:?} - Thread {}",
-            self.client.config().kind,
+            // self.client.config().kind,
+            "asdjkl",
             self.thread_id
         ))
         .color(if params.selected {
@@ -568,7 +569,8 @@ impl Item for DebugPanelItem {
         // TODO debugger: allow showing current thread status
         Some(SharedString::from(format!(
             "{:?} Thread {}",
-            self.client.config().kind,
+            // self.client.config().kind,
+            "asdjkl",
             self.thread_id,
             // self.current_thread_state(cx).status
         )))

--- a/crates/debugger_ui/src/debugger_panel_item.rs
+++ b/crates/debugger_ui/src/debugger_panel_item.rs
@@ -501,10 +501,11 @@ impl DebugPanelItem {
     }
 
     fn handle_disconnect_action(&mut self, cx: &mut ViewContext<Self>) {
-        let client = self.client.clone();
-        cx.background_executor()
-            .spawn(async move { client.disconnect(None, Some(true), None).await })
-            .detach_and_log_err(cx);
+        self.dap_store.update(cx, |store, cx| {
+            store
+                .disconnect_client(&self.client.id(), cx)
+                .detach_and_log_err(cx);
+        });
     }
 }
 

--- a/crates/debugger_ui/src/debugger_panel_item.rs
+++ b/crates/debugger_ui/src/debugger_panel_item.rs
@@ -487,11 +487,13 @@ impl DebugPanelItem {
     }
 
     fn handle_pause_action(&mut self, cx: &mut ViewContext<Self>) {
-        let client = self.client.clone();
-        let thread_id = self.thread_id;
-        cx.background_executor()
-            .spawn(async move { client.pause(thread_id).await })
-            .detach_and_log_err(cx);
+        self.dap_store
+            .update(cx, |store, cx| {
+                store
+                    .pause_thread(&self.client.id(), self.thread_id, cx)
+                    .detach()
+            })
+            .log_err();
     }
 
     fn handle_stop_action(&mut self, cx: &mut ViewContext<Self>) {

--- a/crates/debugger_ui/src/debugger_panel_item.rs
+++ b/crates/debugger_ui/src/debugger_panel_item.rs
@@ -548,14 +548,13 @@ impl Item for DebugPanelItem {
         .into_any_element()
     }
 
-    fn tab_tooltip_text(&self, _: &AppContext) -> Option<SharedString> {
-        // TODO debugger: allow showing current thread status
+    fn tab_tooltip_text(&self, cx: &AppContext) -> Option<SharedString> {
         Some(SharedString::from(format!(
-            "{:?} Thread {}",
+            "{:?} Thread {} - {:?}",
             // self.client.config().kind,
             "asdjkl",
             self.thread_id,
-            // self.current_thread_state(cx).status
+            self.thread_state.read(cx).status,
         )))
     }
 

--- a/crates/debugger_ui/src/debugger_panel_item.rs
+++ b/crates/debugger_ui/src/debugger_panel_item.rs
@@ -438,7 +438,6 @@ impl DebugPanelItem {
     }
 
     fn handle_step_over_action(&mut self, cx: &mut ViewContext<Self>) {
-        let client = self.client.clone();
         let thread_id = self.thread_id;
 
         self.debug_panel.update(cx, |panel, cx| {
@@ -453,9 +452,11 @@ impl DebugPanelItem {
 
         let granularity = DebuggerSettings::get_global(cx).stepping_granularity();
 
-        cx.background_executor()
-            .spawn(async move { client.step_over(thread_id, granularity).await })
-            .detach_and_log_err(cx);
+        self.dap_store.update(cx, |store, cx| {
+            store
+                .step_over(&self.client.id(), thread_id, granularity, cx)
+                .detach_and_log_err(cx);
+        });
     }
 
     fn handle_step_in_action(&mut self, cx: &mut ViewContext<Self>) {

--- a/crates/debugger_ui/src/debugger_panel_item.rs
+++ b/crates/debugger_ui/src/debugger_panel_item.rs
@@ -304,7 +304,6 @@ impl DebugPanelItem {
 
     fn render_stack_frames(&self, _cx: &mut ViewContext<Self>) -> impl IntoElement {
         v_flex()
-            .gap_3()
             .size_full()
             .child(list(self.stack_frame_list.clone()).size_full())
             .into_any()

--- a/crates/debugger_ui/src/debugger_panel_item.rs
+++ b/crates/debugger_ui/src/debugger_panel_item.rs
@@ -88,6 +88,7 @@ impl DebugPanelItem {
 
         let variable_list = cx.new_view(|cx| {
             VariableList::new(
+                dap_store.clone(),
                 &client_id,
                 &thread_state,
                 &capabilities,

--- a/crates/debugger_ui/src/debugger_panel_item.rs
+++ b/crates/debugger_ui/src/debugger_panel_item.rs
@@ -13,6 +13,7 @@ use gpui::{
 use project::dap_store::DapStore;
 use serde::Deserialize;
 use settings::Settings;
+use task::DebugAdapterKind;
 use ui::WindowContext;
 use ui::{prelude::*, Tooltip};
 use workspace::dock::Panel;
@@ -38,6 +39,7 @@ pub struct DebugPanelItem {
     stack_frame_list: ListState,
     output_editor: View<Editor>,
     current_stack_frame_id: u64,
+    client_kind: DebugAdapterKind,
     debug_panel: View<DebugPanel>,
     active_thread_item: ThreadItem,
     workspace: WeakView<Workspace>,
@@ -79,6 +81,7 @@ impl DebugPanelItem {
         dap_store: Model<DapStore>,
         thread_state: Model<ThreadState>,
         client_id: &DebugAdapterClientId,
+        client_kind: &DebugAdapterKind,
         thread_id: u64,
         current_stack_frame_id: u64,
         cx: &mut ViewContext<Self>,
@@ -158,6 +161,7 @@ impl DebugPanelItem {
             stack_frame_list,
             client_id: *client_id,
             current_stack_frame_id,
+            client_kind: client_kind.clone(),
             active_thread_item: ThreadItem::Variables,
         }
     }
@@ -535,9 +539,7 @@ impl Item for DebugPanelItem {
     ) -> AnyElement {
         Label::new(format!(
             "{:?} - Thread {}",
-            // self.client.config().kind,
-            "asdjkl",
-            self.thread_id
+            self.client_kind, self.thread_id
         ))
         .color(if params.selected {
             Color::Default
@@ -550,8 +552,7 @@ impl Item for DebugPanelItem {
     fn tab_tooltip_text(&self, cx: &AppContext) -> Option<SharedString> {
         Some(SharedString::from(format!(
             "{:?} Thread {} - {:?}",
-            // self.client.config().kind,
-            "asdjkl",
+            self.client_kind,
             self.thread_id,
             self.thread_state.read(cx).status,
         )))

--- a/crates/debugger_ui/src/debugger_panel_item.rs
+++ b/crates/debugger_ui/src/debugger_panel_item.rs
@@ -1,5 +1,5 @@
 use crate::console::Console;
-use crate::debugger_panel::{DebugPanel, DebugPanelEvent, ThreadState, VariableContainer};
+use crate::debugger_panel::{DebugPanel, DebugPanelEvent, ThreadState};
 use crate::variable_list::VariableList;
 
 use dap::client::{DebugAdapterClientId, ThreadStatus};
@@ -276,10 +276,6 @@ impl DebugPanelItem {
         self.thread_id
     }
 
-    pub fn current_stack_frame_id(&self) -> u64 {
-        self.current_stack_frame_id
-    }
-
     pub fn capabilities(&self, cx: &mut ViewContext<Self>) -> Capabilities {
         self.dap_store
             .read_with(cx, |store, _| store.capabilities_by_id(&self.client_id))
@@ -299,7 +295,7 @@ impl DebugPanelItem {
 
         self.variable_list.update(cx, |variable_list, cx| {
             variable_list.update_stack_frame_id(stack_frame_id, cx);
-            variable_list.build_entries(stack_frame_id, true, false, cx);
+            variable_list.build_entries(true, false, cx);
         });
 
         cx.notify();

--- a/crates/debugger_ui/src/debugger_panel_item.rs
+++ b/crates/debugger_ui/src/debugger_panel_item.rs
@@ -420,7 +420,6 @@ impl DebugPanelItem {
     }
 
     fn handle_continue_action(&mut self, cx: &mut ViewContext<Self>) {
-        let client = self.client.clone();
         let thread_id = self.thread_id;
 
         self.debug_panel.update(cx, |panel, cx| {
@@ -433,9 +432,13 @@ impl DebugPanelItem {
             );
         });
 
-        cx.background_executor()
-            .spawn(async move { client.resume(thread_id).await })
-            .detach_and_log_err(cx);
+        self.dap_store
+            .update(cx, |store, cx| {
+                store
+                    .continue_thread(&self.client.id(), thread_id, cx)
+                    .detach_and_log_err(cx);
+            })
+            .log_err();
     }
 
     fn handle_step_over_action(&mut self, cx: &mut ViewContext<Self>) {

--- a/crates/debugger_ui/src/debugger_panel_item.rs
+++ b/crates/debugger_ui/src/debugger_panel_item.rs
@@ -294,20 +294,6 @@ impl DebugPanelItem {
             .unwrap()
     }
 
-    pub fn insert_variables(
-        &mut self,
-        variable_id: u64,
-        variables: Vec<VariableContainer>,
-        cx: &mut ViewContext<Self>,
-    ) {
-        self.thread_state.update(cx, |thread_state, cx| {
-            thread_state.variables.insert(variable_id, variables);
-            cx.notify();
-        });
-
-        cx.notify();
-    }
-
     fn update_stack_frame_id(&mut self, stack_frame_id: u64, cx: &mut ViewContext<Self>) {
         self.current_stack_frame_id = stack_frame_id;
 

--- a/crates/debugger_ui/src/debugger_panel_item.rs
+++ b/crates/debugger_ui/src/debugger_panel_item.rs
@@ -305,8 +305,10 @@ impl DebugPanelItem {
 
         let thread_state = self.current_thread_state(cx);
 
-        self.variable_list.update(cx, |variable_list, _| {
+        self.variable_list.update(cx, |variable_list, cx| {
             variable_list.build_entries(thread_state, stack_frame_id, true, false);
+
+            cx.notify();
         });
     }
 

--- a/crates/debugger_ui/src/debugger_panel_item.rs
+++ b/crates/debugger_ui/src/debugger_panel_item.rs
@@ -475,9 +475,11 @@ impl DebugPanelItem {
 
         let granularity = DebuggerSettings::get_global(cx).stepping_granularity();
 
-        cx.background_executor()
-            .spawn(async move { client.step_in(thread_id, granularity).await })
-            .detach_and_log_err(cx);
+        self.dap_store.update(cx, |store, cx| {
+            store
+                .step_in(&self.client.id(), thread_id, granularity, cx)
+                .detach_and_log_err(cx);
+        });
     }
 
     fn handle_step_out_action(&mut self, cx: &mut ViewContext<Self>) {

--- a/crates/debugger_ui/src/debugger_panel_item.rs
+++ b/crates/debugger_ui/src/debugger_panel_item.rs
@@ -72,6 +72,7 @@ enum DebugPanelItemActionKind {
 }
 
 impl DebugPanelItem {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         debug_panel: View<DebugPanel>,
         workspace: WeakView<Workspace>,

--- a/crates/debugger_ui/src/lib.rs
+++ b/crates/debugger_ui/src/lib.rs
@@ -2,6 +2,7 @@ use dap::debugger_settings::DebuggerSettings;
 use debugger_panel::{DebugPanel, ToggleFocus};
 use debugger_panel_item::DebugPanelItem;
 use gpui::AppContext;
+use project::dap_store::{self};
 use settings::Settings;
 use ui::ViewContext;
 use workspace::{StartDebugger, Workspace};
@@ -13,6 +14,7 @@ mod variable_list;
 
 pub fn init(cx: &mut AppContext) {
     DebuggerSettings::register(cx);
+    dap_store::init(cx);
 
     cx.observe_new_views(
         |workspace: &mut Workspace, _cx: &mut ViewContext<Workspace>| {

--- a/crates/debugger_ui/src/variable_list.rs
+++ b/crates/debugger_ui/src/variable_list.rs
@@ -357,8 +357,8 @@ impl VariableList {
             return;
         }
 
-        let (mut thread_state, client) = self.debug_panel_item.update(cx, |panel, cx| {
-            (panel.current_thread_state(cx), panel.client())
+        let (mut thread_state, client_id) = self.debug_panel_item.update(cx, |panel, cx| {
+            (panel.current_thread_state(cx), panel.client_id())
         });
 
         let variables_reference = state.parent_variables_reference;

--- a/crates/debugger_ui/src/variable_list.rs
+++ b/crates/debugger_ui/src/variable_list.rs
@@ -1,6 +1,8 @@
-use crate::debugger_panel_item::DebugPanelItem;
+use crate::{
+    debugger_panel::{ThreadState, VariableContainer},
+    debugger_panel_item::DebugPanelItem,
+};
 use dap::{
-    client::{ThreadState, VariableContainer},
     requests::{SetExpression, SetVariable, Variables},
     Scope, SetExpressionArguments, SetVariableArguments, Variable, VariablesArguments,
 };

--- a/crates/debugger_ui/src/variable_list.rs
+++ b/crates/debugger_ui/src/variable_list.rs
@@ -1,13 +1,5 @@
-use crate::{
-    debugger_panel::{ThreadState, VariableContainer},
-    debugger_panel_item::DebugPanelItem,
-};
-use dap::{
-    client::DebugAdapterClientId,
-    requests::{SetExpression, SetVariable, Variables},
-    Capabilities, Scope, SetExpressionArguments, SetVariableArguments, Variable,
-    VariablesArguments,
-};
+use crate::debugger_panel::{ThreadState, VariableContainer};
+use dap::{client::DebugAdapterClientId, Capabilities, Scope, Variable};
 use editor::{
     actions::{self, SelectAll},
     Editor, EditorEvent,
@@ -18,11 +10,8 @@ use gpui::{
     ListState, Model, MouseDownEvent, Point, Subscription, View,
 };
 use menu::Confirm;
-use project::dap_store::{self, DapStore};
-use std::{
-    collections::{BTreeMap, HashMap, HashSet},
-    sync::Arc,
-};
+use project::dap_store::DapStore;
+use std::{collections::HashMap, sync::Arc};
 use ui::{prelude::*, ContextMenu, ListItem};
 
 #[derive(Debug, Clone)]
@@ -152,6 +141,12 @@ impl VariableList {
         };
 
         self.build_entries(self.stack_frame_id, false, true, cx);
+        cx.notify();
+    }
+
+    pub fn update_stack_frame_id(&mut self, stack_frame_id: u64, cx: &mut ViewContext<Self>) {
+        self.stack_frame_id = stack_frame_id;
+
         cx.notify();
     }
 

--- a/crates/project/src/dap_store.rs
+++ b/crates/project/src/dap_store.rs
@@ -102,7 +102,11 @@ impl DapStore {
         &self.breakpoints
     }
 
-    pub fn merge_capabilities(&mut self, client_id: &DebugAdapterClientId, other: &Capabilities) {
+    pub fn merge_capabilities_for_client(
+        &mut self,
+        client_id: &DebugAdapterClientId,
+        other: &Capabilities,
+    ) {
         if let Some(capabilities) = self.capabilities.get_mut(client_id) {
             *capabilities = capabilities.merge(other.clone());
         }

--- a/crates/project/src/dap_store.rs
+++ b/crates/project/src/dap_store.rs
@@ -242,8 +242,10 @@ impl DapStore {
                 })
                 .await?;
 
-            this.update(&mut cx, |store, _| {
+            this.update(&mut cx, |store, cx| {
                 store.capabilities.insert(client.id(), capabilities);
+
+                cx.notify();
             })?;
 
             // send correct request based on adapter config
@@ -532,6 +534,8 @@ impl DapStore {
         cx.emit(DapStoreEvent::DebugClientStopped(*client_id));
 
         self.capabilities.remove(client_id);
+
+        cx.notify();
 
         cx.spawn(|_, _| async move {
             match debug_client {

--- a/crates/project/src/dap_store.rs
+++ b/crates/project/src/dap_store.rs
@@ -3,7 +3,7 @@ use collections::{HashMap, HashSet};
 use dap::client::{DebugAdapterClient, DebugAdapterClientId};
 use dap::messages::Message;
 use dap::SourceBreakpoint;
-use gpui::{EventEmitter, ModelContext, Task};
+use gpui::{AppContext, Context, EventEmitter, Global, Model, ModelContext, Task};
 use language::{Buffer, BufferSnapshot};
 use settings::WorktreeId;
 use std::{
@@ -43,7 +43,20 @@ pub struct DapStore {
 
 impl EventEmitter<DapStoreEvent> for DapStore {}
 
+struct GlobalDapStore(Model<DapStore>);
+
+impl Global for GlobalDapStore {}
+
+pub fn init(cx: &mut AppContext) {
+    let store = GlobalDapStore(cx.new_model(DapStore::new));
+    cx.set_global(store);
+}
+
 impl DapStore {
+    pub fn global(cx: &AppContext) -> Model<Self> {
+        cx.global::<GlobalDapStore>().0.clone()
+    }
+
     pub fn new(cx: &mut ModelContext<Self>) -> Self {
         cx.on_app_quit(Self::shutdown_clients).detach();
 

--- a/crates/project/src/dap_store.rs
+++ b/crates/project/src/dap_store.rs
@@ -109,9 +109,12 @@ impl DapStore {
         &mut self,
         client_id: &DebugAdapterClientId,
         other: &Capabilities,
+        cx: &mut ModelContext<Self>,
     ) {
         if let Some(capabilities) = self.capabilities.get_mut(client_id) {
             *capabilities = capabilities.merge(other.clone());
+
+            cx.notify();
         }
     }
 
@@ -437,6 +440,7 @@ impl DapStore {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn set_variable_value(
         &self,
         client_id: &DebugAdapterClientId,

--- a/crates/project/src/dap_store.rs
+++ b/crates/project/src/dap_store.rs
@@ -4,13 +4,13 @@ use dap::client::{DebugAdapterClient, DebugAdapterClientId};
 use dap::messages::Message;
 use dap::requests::{
     Attach, ConfigurationDone, Continue, Disconnect, Initialize, Launch, Next, Pause, StepIn,
-    TerminateThreads,
+    StepOut, TerminateThreads,
 };
 use dap::{
     AttachRequestArguments, Capabilities, ConfigurationDoneArguments, ContinueArguments,
     DisconnectArguments, InitializeRequestArguments, InitializeRequestArgumentsPathFormat,
     LaunchRequestArguments, NextArguments, PauseArguments, SourceBreakpoint, StepInArguments,
-    SteppingGranularity, TerminateThreadsArguments,
+    StepOutArguments, SteppingGranularity, TerminateThreadsArguments,
 };
 use gpui::{AppContext, Context, EventEmitter, Global, Model, ModelContext, Task};
 use language::{Buffer, BufferSnapshot};
@@ -374,6 +374,37 @@ impl DapStore {
                     granularity: supports_stepping_granularity.then(|| granularity),
                     single_thread: supports_single_thread_execution_requests.then(|| true),
                     target_id: None,
+                })
+                .await
+        })
+    }
+
+    pub fn step_out(
+        &mut self,
+        client_id: &DebugAdapterClientId,
+        thread_id: u64,
+        granularity: SteppingGranularity,
+        cx: &mut ModelContext<Self>,
+    ) -> Task<Result<()>> {
+        let Some(client) = self.client_by_id(client_id) else {
+            return Task::ready(Err(anyhow!("Could not found client")));
+        };
+
+        let capabilities = self.capabilities_by_id(client_id);
+
+        let supports_single_thread_execution_requests = capabilities
+            .supports_single_thread_execution_requests
+            .unwrap_or_default();
+        let supports_stepping_granularity = capabilities
+            .supports_stepping_granularity
+            .unwrap_or_default();
+
+        cx.spawn(|_, _| async move {
+            client
+                .request::<StepOut>(StepOutArguments {
+                    thread_id,
+                    granularity: supports_stepping_granularity.then(|| granularity),
+                    single_thread: supports_single_thread_execution_requests.then(|| true),
                 })
                 .await
         })

--- a/crates/project/src/dap_store.rs
+++ b/crates/project/src/dap_store.rs
@@ -531,6 +531,8 @@ impl DapStore {
 
         cx.emit(DapStoreEvent::DebugClientStopped(*client_id));
 
+        self.capabilities.remove(client_id);
+
         cx.spawn(|_, _| async move {
             match debug_client {
                 DebugAdapterClientState::Starting(task) => {

--- a/crates/project/src/dap_store.rs
+++ b/crates/project/src/dap_store.rs
@@ -377,8 +377,8 @@ impl DapStore {
     fn shutdown_clients(&mut self, cx: &mut ModelContext<Self>) -> impl Future<Output = ()> {
         let mut tasks = Vec::new();
 
-        let keys = self.clients.keys().cloned().collect::<Vec<_>>();
-        for client_id in keys {
+        let client_ids = self.clients.keys().cloned().collect::<Vec<_>>();
+        for client_id in client_ids {
             tasks.push(self.shutdown_client(&client_id, cx));
         }
 

--- a/crates/project/src/dap_store.rs
+++ b/crates/project/src/dap_store.rs
@@ -98,10 +98,6 @@ impl DapStore {
             .unwrap_or_default()
     }
 
-    pub fn breakpoints(&self) -> &BTreeMap<ProjectPath, HashSet<Breakpoint>> {
-        &self.breakpoints
-    }
-
     pub fn merge_capabilities_for_client(
         &mut self,
         client_id: &DebugAdapterClientId,
@@ -110,6 +106,10 @@ impl DapStore {
         if let Some(capabilities) = self.capabilities.get_mut(client_id) {
             *capabilities = capabilities.merge(other.clone());
         }
+    }
+
+    pub fn breakpoints(&self) -> &BTreeMap<ProjectPath, HashSet<Breakpoint>> {
+        &self.breakpoints
     }
 
     pub fn set_active_breakpoints(&mut self, project_path: &ProjectPath, buffer: &Buffer) {

--- a/crates/project/src/dap_store.rs
+++ b/crates/project/src/dap_store.rs
@@ -3,14 +3,14 @@ use collections::{HashMap, HashSet};
 use dap::client::{DebugAdapterClient, DebugAdapterClientId};
 use dap::messages::Message;
 use dap::requests::{
-    Attach, ConfigurationDone, Continue, Disconnect, Initialize, Launch, Next, Pause,
+    Attach, ConfigurationDone, Continue, Disconnect, Initialize, Launch, Next, Pause, StepIn,
     TerminateThreads,
 };
 use dap::{
     AttachRequestArguments, Capabilities, ConfigurationDoneArguments, ContinueArguments,
     DisconnectArguments, InitializeRequestArguments, InitializeRequestArgumentsPathFormat,
-    LaunchRequestArguments, NextArguments, PauseArguments, SourceBreakpoint, SteppingGranularity,
-    TerminateThreadsArguments,
+    LaunchRequestArguments, NextArguments, PauseArguments, SourceBreakpoint, StepInArguments,
+    SteppingGranularity, TerminateThreadsArguments,
 };
 use gpui::{AppContext, Context, EventEmitter, Global, Model, ModelContext, Task};
 use language::{Buffer, BufferSnapshot};
@@ -342,6 +342,38 @@ impl DapStore {
                     thread_id,
                     granularity: supports_stepping_granularity.then(|| granularity),
                     single_thread: supports_single_thread_execution_requests.then(|| true),
+                })
+                .await
+        })
+    }
+
+    pub fn step_in(
+        &mut self,
+        client_id: &DebugAdapterClientId,
+        thread_id: u64,
+        granularity: SteppingGranularity,
+        cx: &mut ModelContext<Self>,
+    ) -> Task<Result<()>> {
+        let Some(client) = self.client_by_id(client_id) else {
+            return Task::ready(Err(anyhow!("Could not found client")));
+        };
+
+        let capabilities = self.capabilities_by_id(client_id);
+
+        let supports_single_thread_execution_requests = capabilities
+            .supports_single_thread_execution_requests
+            .unwrap_or_default();
+        let supports_stepping_granularity = capabilities
+            .supports_stepping_granularity
+            .unwrap_or_default();
+
+        cx.spawn(|_, _| async move {
+            client
+                .request::<StepIn>(StepInArguments {
+                    thread_id,
+                    granularity: supports_stepping_granularity.then(|| granularity),
+                    single_thread: supports_single_thread_execution_requests.then(|| true),
+                    target_id: None,
                 })
                 .await
         })

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -644,6 +644,8 @@ impl Project {
         env: Option<HashMap<String, String>>,
         cx: &mut AppContext,
     ) -> Model<Self> {
+        let dap_store = DapStore::global(cx);
+
         cx.new_model(|cx: &mut ModelContext<Self>| {
             let (tx, rx) = mpsc::unbounded();
             cx.spawn(move |this, cx| Self::send_buffer_ordered_messages(this, rx, cx))
@@ -656,8 +658,6 @@ impl Project {
             let worktree_store = cx.new_model(|_| WorktreeStore::new(false, fs.clone()));
             cx.subscribe(&worktree_store, Self::on_worktree_store_event)
                 .detach();
-
-            let dap_store = cx.new_model(DapStore::new);
 
             let buffer_store = cx.new_model(|cx| {
                 BufferStore::new(worktree_store.clone(), None, dap_store.clone(), cx)
@@ -849,7 +849,7 @@ impl Project {
             store
         })?;
 
-        let dap_store = cx.new_model(DapStore::new)?;
+        let dap_store = cx.update(|cx| DapStore::global(cx))?;
 
         let buffer_store = cx.new_model(|cx| {
             BufferStore::new(

--- a/crates/remote_server/src/headless_project.rs
+++ b/crates/remote_server/src/headless_project.rs
@@ -43,7 +43,7 @@ impl HeadlessProject {
             Task::ready(()),
             cx.background_executor().clone(),
         ));
-        let dap_store = cx.new_model(DapStore::new);
+        let dap_store = cx.read(DapStore::global).clone();
 
         let worktree_store = cx.new_model(|_| WorktreeStore::new(true, fs.clone()));
         let buffer_store = cx.new_model(|cx| {

--- a/crates/remote_server/src/headless_project.rs
+++ b/crates/remote_server/src/headless_project.rs
@@ -43,7 +43,7 @@ impl HeadlessProject {
             Task::ready(()),
             cx.background_executor().clone(),
         ));
-        let dap_store = cx.read(DapStore::global).clone();
+        let dap_store = DapStore::global(cx);
 
         let worktree_store = cx.new_model(|_| WorktreeStore::new(true, fs.clone()));
         let buffer_store = cx.new_model(|cx| {


### PR DESCRIPTION
This PR refactors the specific request code from the **dap::client** crate to the **project::dap_store** crate. As discussed in our meeting with Mikayla & Piotr on 09/11/24.

TODO's
- [x] Move all the specific request methods from the client to the **dap_store**
- [ ] Make clear highlights work again
  - [ ] Add state to the **dap_store** of opened stack frames so we know what to clear
- [x] Fix recursive dependency in variable_list & debug_panel_item
- [x] Make set variable value work again
- [x] Make toggle variables work again
- [x] Fix panic when debug session ends
- [x] Move fetch initialize data code to dap store
- [x] Show adapter name in thread tab

/cc @Anthony-Eid 

-----
## Changes
This PR moves the **ThreadState** and **VariableContainer** types out of the client module, and move it to the debugger UI crate, where it belongs.  I made the **ThreadState** type a **model**, this allows us to remove the circular dependency that we had with **debugger_panel_item** -> **variabel_list**. So we can just share the **Model<ThreadState>** around without needing a reference to **DebugPanel** itself.

Because we moved all the request code to the **dap_store** it also made sense to move the capabilities to the **dap_store**, because it's responsible for sending the correct data through the client. We now also merge the capabilities when we get the **Initialized** event, to make sure we have the most up-to-date capabilities.

## Followup PR
This PR broke one feature that already needed a refactor before. So after this PR is merged, I'm going to refactor how we show the current debug line and store this information so we can reopen a buffer and directly highlight the debug current line.