### PR TITLE
Move all the debug panel actions to the workspace

### DIFF
--- a/crates/debugger_ui/src/lib.rs
+++ b/crates/debugger_ui/src/lib.rs
@@ -1,10 +1,9 @@
 use dap::debugger_settings::DebuggerSettings;
 use debugger_panel::{DebugPanel, ToggleFocus};
-use debugger_panel_item::DebugPanelItem;
 use gpui::AppContext;
 use settings::Settings;
 use ui::ViewContext;
-use workspace::{StartDebugger, Workspace};
+use workspace::{Continue, Pause, Restart, Start, StepInto, StepOut, StepOver, Stop, Workspace};
 
 mod console;
 pub mod debugger_panel;
@@ -20,10 +19,86 @@ pub fn init(cx: &mut AppContext) {
                 .register_action(|workspace, _: &ToggleFocus, cx| {
                     workspace.toggle_panel_focus::<DebugPanel>(cx);
                 })
-                .register_action(|workspace: &mut Workspace, _: &StartDebugger, cx| {
+                .register_action(|workspace: &mut Workspace, _: &Start, cx| {
                     tasks_ui::toggle_modal(workspace, cx, task::TaskModal::DebugModal).detach();
                 })
-                .register_action(DebugPanelItem::workspace_action_handler);
+                .register_action(|workspace: &mut Workspace, _: &Stop, cx| {
+                    let debug_panel = workspace.panel::<DebugPanel>(cx).unwrap();
+
+                    debug_panel.update(cx, |panel, cx| {
+                        let Some(active_item) = panel.active_debug_panel_item(cx) else {
+                            return;
+                        };
+
+                        active_item.update(cx, |item, cx| item.stop_thread(cx))
+                    });
+                })
+                .register_action(|workspace: &mut Workspace, _: &Continue, cx| {
+                    let debug_panel = workspace.panel::<DebugPanel>(cx).unwrap();
+
+                    debug_panel.update(cx, |panel, cx| {
+                        let Some(active_item) = panel.active_debug_panel_item(cx) else {
+                            return;
+                        };
+
+                        active_item.update(cx, |item, cx| item.continue_thread(cx))
+                    });
+                })
+                .register_action(|workspace: &mut Workspace, _: &StepInto, cx| {
+                    let debug_panel = workspace.panel::<DebugPanel>(cx).unwrap();
+
+                    debug_panel.update(cx, |panel, cx| {
+                        let Some(active_item) = panel.active_debug_panel_item(cx) else {
+                            return;
+                        };
+
+                        active_item.update(cx, |item, cx| item.step_in(cx))
+                    });
+                })
+                .register_action(|workspace: &mut Workspace, _: &StepOut, cx| {
+                    let debug_panel = workspace.panel::<DebugPanel>(cx).unwrap();
+
+                    debug_panel.update(cx, |panel, cx| {
+                        let Some(active_item) = panel.active_debug_panel_item(cx) else {
+                            return;
+                        };
+
+                        active_item.update(cx, |item, cx| item.step_out(cx))
+                    });
+                })
+                .register_action(|workspace: &mut Workspace, _: &StepOver, cx| {
+                    let debug_panel = workspace.panel::<DebugPanel>(cx).unwrap();
+
+                    debug_panel.update(cx, |panel, cx| {
+                        let Some(active_item) = panel.active_debug_panel_item(cx) else {
+                            return;
+                        };
+
+                        active_item.update(cx, |item, cx| item.step_over(cx))
+                    });
+                })
+                .register_action(|workspace: &mut Workspace, _: &Restart, cx| {
+                    let debug_panel = workspace.panel::<DebugPanel>(cx).unwrap();
+
+                    debug_panel.update(cx, |panel, cx| {
+                        let Some(active_item) = panel.active_debug_panel_item(cx) else {
+                            return;
+                        };
+
+                        active_item.update(cx, |item, cx| item.restart_client(cx))
+                    });
+                })
+                .register_action(|workspace: &mut Workspace, _: &Pause, cx| {
+                    let debug_panel = workspace.panel::<DebugPanel>(cx).unwrap();
+
+                    debug_panel.update(cx, |panel, cx| {
+                        let Some(active_item) = panel.active_debug_panel_item(cx) else {
+                            return;
+                        };
+
+                        active_item.update(cx, |item, cx| item.pause_thread(cx))
+                    });
+                });
         },
     )
     .detach();

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -126,6 +126,11 @@ pub struct RemoveWorktreeFromProject(pub WorktreeId);
 actions!(assistant, [ShowConfiguration]);
 
 actions!(
+    debugger,
+    [Start, Continue, Disconnect, Pause, Restart, StepInto, StepOver, StepOut, Stop]
+);
+
+actions!(
     workspace,
     [
         ActivateNextPane,
@@ -150,7 +155,6 @@ actions!(
         ReloadActiveItem,
         SaveAs,
         SaveWithoutFormat,
-        StartDebugger,
         ToggleBottomDock,
         ToggleCenteredLayout,
         ToggleLeftDock,


### PR DESCRIPTION
This PR moves out all the actions from the **debug_panel_item** to the **workspace** which allows people to use these actions inside their key binds.

I also had to remove the debug_panel dependency inside the debug_panel_item, because we hit a `"cannot update debug_panel while it is already being updated"` panic. So instead of updating the thread status inside the **debug_panel** we now do this inside the **debug_panel_item** to prevent this panic. 

I also move the actions to its own debugger namespace, so it's more clear what the actions are for.

The new actions can now also be used for key binds:
```
debugger: start
debugger: continue
debugger: step into
debugger: step over
debugger: step out
debugger: restart
debugger: stop
debugger: pause
```

/cc @Anthony-Eid We now can have key binds for debugger actions.