### PR TITLE
Show current debug line when you reopen a buffer

### DIFF
--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -9,7 +9,6 @@ use dap::{
     Capabilities, ContinuedEvent, ExitedEvent, OutputEvent, Scope, StackFrame, StoppedEvent,
     TerminatedEvent, ThreadEvent, ThreadEventReason, Variable,
 };
-use editor::Editor;
 use futures::future::try_join_all;
 use gpui::{
     actions, Action, AppContext, AsyncWindowContext, EventEmitter, FocusHandle, FocusableView,
@@ -18,7 +17,6 @@ use gpui::{
 use project::dap_store::DapStore;
 use settings::Settings;
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::path::Path;
 use std::sync::Arc;
 use std::u64;
 use ui::prelude::*;
@@ -28,11 +26,13 @@ use workspace::{
 };
 use workspace::{pane, Pane, Start};
 
-enum DebugCurrentRowHighlight {}
-
 pub enum DebugPanelEvent {
     Exited(DebugAdapterClientId),
-    Stopped((DebugAdapterClientId, StoppedEvent)),
+    Stopped {
+        client_id: DebugAdapterClientId,
+        event: StoppedEvent,
+        go_to_stack_frame: bool,
+    },
     Thread((DebugAdapterClientId, ThreadEvent)),
     Continued((DebugAdapterClientId, ContinuedEvent)),
     Output((DebugAdapterClientId, OutputEvent)),
@@ -213,6 +213,19 @@ impl DebugPanel {
                     })
                     .ok();
             }
+            pane::Event::ActivateItem { local } => {
+                if !local {
+                    return;
+                }
+
+                if let Some(active_item) = self.pane.read(cx).active_item() {
+                    if let Some(debug_item) = active_item.downcast::<DebugPanelItem>() {
+                        debug_item.update(cx, |panel, cx| {
+                            panel.go_to_stack_frame(cx);
+                        });
+                    }
+                }
+            }
             _ => {}
         }
     }
@@ -254,129 +267,6 @@ impl DebugPanel {
             Events::Other(_) => {}
         }
     }
-
-    pub async fn go_to_stack_frame(
-        workspace: WeakView<Workspace>,
-        stack_frame: StackFrame,
-        clear_highlights: bool,
-        mut cx: AsyncWindowContext,
-    ) -> Result<()> {
-        let Some(path) = &stack_frame.source.and_then(|s| s.path) else {
-            return Err(anyhow::anyhow!(
-                "Cannot go to stack frame, path doesn't exist"
-            ));
-        };
-
-        let row = (stack_frame.line.saturating_sub(1)) as u32;
-        let column = (stack_frame.column.saturating_sub(1)) as u32;
-
-        if clear_highlights {
-            Self::remove_highlights(workspace.clone(), cx.clone())?;
-        }
-
-        let task = workspace.update(&mut cx, |workspace, cx| {
-            let project_path = workspace.project().read_with(cx, |project, cx| {
-                project.project_path_for_absolute_path(&Path::new(&path), cx)
-            });
-
-            if let Some(project_path) = project_path {
-                workspace.open_path_preview(project_path, None, false, true, cx)
-            } else {
-                Task::ready(Err(anyhow::anyhow!(
-                    "No project path found for path: {}",
-                    path
-                )))
-            }
-        })?;
-
-        let editor = task.await?.downcast::<Editor>().unwrap();
-
-        workspace.update(&mut cx, |_, cx| {
-            editor.update(cx, |editor, cx| {
-                editor.go_to_line::<DebugCurrentRowHighlight>(
-                    row,
-                    column,
-                    Some(cx.theme().colors().editor_debugger_active_line_background),
-                    cx,
-                );
-            })
-        })
-    }
-
-    fn remove_highlights(workspace: WeakView<Workspace>, mut cx: AsyncWindowContext) -> Result<()> {
-        workspace.update(&mut cx, |workspace, cx| {
-            let editor_views = workspace
-                .items_of_type::<Editor>(cx)
-                .collect::<Vec<View<Editor>>>();
-
-            for editor_view in editor_views {
-                editor_view.update(cx, |editor, _| {
-                    editor.clear_row_highlights::<DebugCurrentRowHighlight>();
-                });
-            }
-        })
-    }
-
-    // async fn remove_highlights_for_thread(
-    //     workspace: WeakView<Workspace>,
-    //     client: Arc<DebugAdapterClient>,
-    //     thread_id: u64,
-    //     cx: AsyncWindowContext,
-    // ) -> Result<()> {
-    //     let mut tasks = Vec::new();
-    //     let mut paths: HashSet<String> = HashSet::new();
-    //     let thread_state = client.thread_state_by_id(thread_id);
-
-    //     for stack_frame in thread_state.stack_frames.into_iter() {
-    //         let Some(path) = stack_frame.source.clone().and_then(|s| s.path.clone()) else {
-    //             continue;
-    //         };
-
-    //         if paths.contains(&path) {
-    //             continue;
-    //         }
-
-    //         paths.insert(path.clone());
-    //         tasks.push(Self::remove_editor_highlight(
-    //             workspace.clone(),
-    //             path,
-    //             cx.clone(),
-    //         ));
-    //     }
-
-    //     if !tasks.is_empty() {
-    //         try_join_all(tasks).await?;
-    //     }
-
-    //     anyhow::Ok(())
-    // }
-
-    // async fn remove_editor_highlight(
-    //     workspace: WeakView<Workspace>,
-    //     path: String,
-    //     mut cx: AsyncWindowContext,
-    // ) -> Result<()> {
-    //     let task = workspace.update(&mut cx, |workspace, cx| {
-    //         let project_path = workspace.project().read_with(cx, |project, cx| {
-    //             project.project_path_for_absolute_path(&Path::new(&path), cx)
-    //         });
-
-    //         if let Some(project_path) = project_path {
-    //             workspace.open_path(project_path, None, false, cx)
-    //         } else {
-    //             Task::ready(Err(anyhow::anyhow!(
-    //                 "No project path found for path: {}",
-    //                 path
-    //             )))
-    //         }
-    //     })?;
-
-    //     let editor = task.await?.downcast::<Editor>().unwrap();
-
-    //     editor.update(&mut cx, |editor, _| {
-    //         editor.clear_row_highlights::<DebugCurrentRowHighlight>();
-    //     })
-    // }
 
     fn handle_initialized_event(
         &mut self,
@@ -561,31 +451,24 @@ impl DebugPanel {
                         });
                     }
 
-                    cx.emit(DebugPanelEvent::Stopped((client_id, event)));
+                    let go_to_stack_frame = if let Some(item) = this.pane.read(cx).active_item() {
+                        item.downcast::<DebugPanelItem>().map_or(false, |pane| {
+                            let pane = pane.read(cx);
+
+                            pane.thread_id() == thread_id && pane.client_id() == client_id
+                        })
+                    } else {
+                        true
+                    };
+
+                    cx.emit(DebugPanelEvent::Stopped {
+                        client_id,
+                        event,
+                        go_to_stack_frame,
+                    });
 
                     cx.notify();
-
-                    if let Some(item) = this.pane.read(cx).active_item() {
-                        if let Some(pane) = item.downcast::<DebugPanelItem>() {
-                            let pane = pane.read(cx);
-                            if pane.thread_id() == thread_id && pane.client_id() == client_id {
-                                let workspace = this.workspace.clone();
-                                return cx.spawn(|_, cx| async move {
-                                    Self::go_to_stack_frame(
-                                        workspace,
-                                        current_stack_frame.clone(),
-                                        true,
-                                        cx,
-                                    )
-                                    .await
-                                });
-                            }
-                        }
-                    }
-
-                    Task::ready(anyhow::Ok(()))
-                })?
-                .await
+                })
             }
         })
         .detach_and_log_err(cx);

--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -28,6 +28,7 @@ use workspace::{pane, Pane, Start};
 
 pub enum DebugPanelEvent {
     Exited(DebugAdapterClientId),
+    Terminated(DebugAdapterClientId),
     Stopped {
         client_id: DebugAdapterClientId,
         event: StoppedEvent,
@@ -516,8 +517,6 @@ impl DebugPanel {
     ) {
         let restart_args = event.clone().and_then(|e| e.restart);
 
-        // TODO debugger: remove current highlights
-
         self.dap_store.update(cx, |store, cx| {
             if restart_args.is_some() {
                 store
@@ -527,6 +526,8 @@ impl DebugPanel {
                 store.shutdown_client(&client_id, cx).detach_and_log_err(cx);
             }
         });
+
+        cx.emit(DebugPanelEvent::Terminated(*client_id));
     }
 
     fn handle_output_event(

--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -494,19 +494,6 @@ impl DebugPanel {
                 (*client_id, thread_id),
                 cx.new_model(|_| ThreadState::default()),
             );
-        } else {
-            // TODO debugger: we want to figure out for witch clients/threads we should remove the highlights
-            // cx.spawn({
-            //     let client = client.clone();
-            //     |this, mut cx| async move {
-            //         let workspace = this.update(&mut cx, |this, _| this.workspace.clone())?;
-
-            //         Self::remove_highlights_for_thread(workspace, client, thread_id, cx).await?;
-
-            //         anyhow::Ok(())
-            //     }
-            // })
-            // .detach_and_log_err(cx);
         }
 
         cx.emit(DebugPanelEvent::Thread((*client_id, event.clone())));

--- a/crates/debugger_ui/src/debugger_panel_item.rs
+++ b/crates/debugger_ui/src/debugger_panel_item.rs
@@ -351,9 +351,7 @@ impl DebugPanelItem {
         stack_frame: &StackFrame,
         cx: &mut ViewContext<Self>,
     ) -> Option<ProjectPath> {
-        let Some(path) = stack_frame.source.as_ref().and_then(|s| s.path.as_ref()) else {
-            return None;
-        };
+        let path = stack_frame.source.as_ref().and_then(|s| s.path.as_ref())?;
 
         self.workspace
             .update(cx, |workspace, cx| {

--- a/crates/debugger_ui/src/debugger_panel_item.rs
+++ b/crates/debugger_ui/src/debugger_panel_item.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::path::Path;
 
 use crate::console::Console;
@@ -13,8 +12,8 @@ use dap::{
 };
 use editor::Editor;
 use gpui::{
-    list, AnyElement, AppContext, Entity, EventEmitter, FocusHandle, FocusableView, ListState,
-    Model, Subscription, Task, View, WeakView,
+    list, AnyElement, AppContext, EventEmitter, FocusHandle, FocusableView, ListState, Model,
+    Subscription, Task, View, WeakView,
 };
 use project::dap_store::DapStore;
 use settings::Settings;
@@ -369,7 +368,7 @@ impl DebugPanelItem {
         cx.spawn({
             let workspace = self.workspace.clone();
             let path = path.clone();
-            |this, mut cx| async move {
+            |_, mut cx| async move {
                 let task = workspace.update(&mut cx, |workspace, cx| {
                     let project_path = workspace.project().read_with(cx, |project, cx| {
                         project.project_path_for_absolute_path(&Path::new(&path), cx)

--- a/crates/debugger_ui/src/debugger_panel_item.rs
+++ b/crates/debugger_ui/src/debugger_panel_item.rs
@@ -1,3 +1,6 @@
+use std::any::Any;
+use std::path::Path;
+
 use crate::console::Console;
 use crate::debugger_panel::{DebugPanel, DebugPanelEvent, ThreadState};
 use crate::variable_list::VariableList;
@@ -10,8 +13,8 @@ use dap::{
 };
 use editor::Editor;
 use gpui::{
-    list, AnyElement, AppContext, EventEmitter, FocusHandle, FocusableView, ListState, Model,
-    Subscription, View, WeakView,
+    list, AnyElement, AppContext, Entity, EventEmitter, FocusHandle, FocusableView, ListState,
+    Model, Subscription, Task, View, WeakView,
 };
 use project::dap_store::DapStore;
 use settings::Settings;
@@ -93,9 +96,11 @@ impl DebugPanelItem {
         let _subscriptions = vec![cx.subscribe(&debug_panel, {
             move |this: &mut Self, _, event: &DebugPanelEvent, cx| {
                 match event {
-                    DebugPanelEvent::Stopped((client_id, event)) => {
-                        this.handle_stopped_event(client_id, event, cx)
-                    }
+                    DebugPanelEvent::Stopped {
+                        client_id,
+                        event,
+                        go_to_stack_frame,
+                    } => this.handle_stopped_event(client_id, event, *go_to_stack_frame, cx),
                     DebugPanelEvent::Thread((client_id, event)) => {
                         this.handle_thread_event(client_id, event, cx)
                     }
@@ -178,6 +183,7 @@ impl DebugPanelItem {
         &mut self,
         client_id: &DebugAdapterClientId,
         event: &StoppedEvent,
+        go_to_stack_frame: bool,
         cx: &mut ViewContext<Self>,
     ) {
         if self.should_skip_event(client_id, event.thread_id.unwrap_or(self.thread_id)) {
@@ -188,7 +194,7 @@ impl DebugPanelItem {
 
         self.stack_frame_list.reset(thread_state.stack_frames.len());
         if let Some(stack_frame) = thread_state.stack_frames.first() {
-            self.update_stack_frame_id(stack_frame.id, cx);
+            self.update_stack_frame_id(stack_frame.id, go_to_stack_frame, cx);
         };
 
         cx.notify();
@@ -268,6 +274,8 @@ impl DebugPanelItem {
 
         self.update_thread_state_status(ThreadStatus::Stopped, cx);
 
+        self.remove_highlights(cx);
+
         cx.emit(Event::Close);
     }
 
@@ -299,15 +307,15 @@ impl DebugPanelItem {
     }
 
     fn stack_frame_for_index(&self, ix: usize, cx: &mut ViewContext<Self>) -> StackFrame {
-        self.thread_state
-            .read(cx)
-            .stack_frames
-            .get(ix)
-            .cloned()
-            .unwrap()
+        self.thread_state.read(cx).stack_frames[ix].clone()
     }
 
-    fn update_stack_frame_id(&mut self, stack_frame_id: u64, cx: &mut ViewContext<Self>) {
+    fn update_stack_frame_id(
+        &mut self,
+        stack_frame_id: u64,
+        go_to_stack_frame: bool,
+        cx: &mut ViewContext<Self>,
+    ) {
         self.current_stack_frame_id = stack_frame_id;
 
         self.variable_list.update(cx, |variable_list, cx| {
@@ -315,7 +323,83 @@ impl DebugPanelItem {
             variable_list.build_entries(true, false, cx);
         });
 
+        if go_to_stack_frame {
+            self.go_to_stack_frame(cx);
+        }
+
         cx.notify();
+    }
+
+    fn remove_highlights(&self, cx: &mut ViewContext<Self>) {
+        self.workspace
+            .update(cx, |workspace, cx| {
+                let editor_views = workspace
+                    .items_of_type::<Editor>(cx)
+                    .collect::<Vec<View<Editor>>>();
+
+                for editor_view in editor_views {
+                    editor_view.update(cx, |editor, _| {
+                        editor.clear_row_highlights::<editor::DebugCurrentRowHighlight>();
+                    });
+                }
+            })
+            .ok();
+    }
+
+    pub fn go_to_stack_frame(&mut self, cx: &mut ViewContext<Self>) {
+        self.remove_highlights(cx);
+
+        let Some(stack_frame) = self
+            .thread_state
+            .read(cx)
+            .stack_frames
+            .iter()
+            .find(|s| s.id == self.current_stack_frame_id)
+        else {
+            return;
+        };
+
+        let Some(path) = stack_frame.source.as_ref().and_then(|s| s.path.as_ref()) else {
+            return;
+        };
+
+        let row = (stack_frame.line.saturating_sub(1)) as u32;
+        let column = (stack_frame.column.saturating_sub(1)) as u32;
+
+        cx.spawn({
+            let workspace = self.workspace.clone();
+            let path = path.clone();
+            |this, mut cx| async move {
+                let task = workspace.update(&mut cx, |workspace, cx| {
+                    let project_path = workspace.project().read_with(cx, |project, cx| {
+                        project.project_path_for_absolute_path(&Path::new(&path), cx)
+                    });
+
+                    if let Some(project_path) = project_path {
+                        workspace.open_path_preview(project_path, None, false, true, cx)
+                    } else {
+                        Task::ready(Err(anyhow::anyhow!(
+                            "No project path found for path: {}",
+                            path
+                        )))
+                    }
+                })?;
+
+                let editor = task.await?.downcast::<Editor>().unwrap();
+
+                workspace.update(&mut cx, |_, cx| {
+                    editor.update(cx, |editor, cx| {
+                        editor.go_to_line::<editor::DebugCurrentRowHighlight>(
+                            row,
+                            column,
+                            Some(cx.theme().colors().editor_debugger_active_line_background),
+                            cx,
+                        );
+                    })
+                })
+            }
+        })
+        .detach_and_log_err(cx);
     }
 
     fn render_stack_frames(&self, _cx: &mut ViewContext<Self>) -> impl IntoElement {
@@ -352,18 +436,8 @@ impl DebugPanelItem {
             })
             .on_click(cx.listener({
                 let stack_frame_id = stack_frame.id;
-                let stack_frame = stack_frame.clone();
                 move |this, _, cx| {
-                    this.update_stack_frame_id(stack_frame_id, cx);
-
-                    let workspace = this.workspace.clone();
-                    let stack_frame = stack_frame.clone();
-                    cx.spawn(|_, cx| async move {
-                        DebugPanel::go_to_stack_frame(workspace, stack_frame, true, cx).await
-                    })
-                    .detach_and_log_err(cx);
-
-                    cx.notify();
+                    this.update_stack_frame_id(stack_frame_id, true, cx);
                 }
             }))
             .hover(|s| s.bg(cx.theme().colors().element_hover).cursor_pointer())

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2024,6 +2024,8 @@ impl Editor {
                 this.git_blame_inline_enabled = true;
                 this.start_git_blame_inline(false, cx);
             }
+
+            this.go_to_active_debug_line(cx);
         }
 
         this.report_editor_event("open", None, cx);
@@ -11306,6 +11308,31 @@ impl Editor {
                 if let Some(path) = file.path().to_str() {
                     cx.write_to_clipboard(ClipboardItem::new_string(path.to_string()));
                 }
+            }
+        }
+    }
+
+    pub fn go_to_active_debug_line(&mut self, cx: &mut ViewContext<Self>) {
+        let Some(dap_store) = self.dap_store.as_ref() else {
+            return;
+        };
+
+        let Some(buffer) = self.buffer.read(cx).as_singleton() else {
+            return;
+        };
+
+        let Some(project_path) = buffer.read_with(cx, |buffer, cx| buffer.project_path(cx)) else {
+            return;
+        };
+
+        if let Some((path, position)) = dap_store.read(cx).active_debug_line() {
+            if path == project_path {
+                self.go_to_line::<DebugCurrentRowHighlight>(
+                    position.row,
+                    position.column,
+                    Some(cx.theme().colors().editor_debugger_active_line_background),
+                    cx,
+                );
             }
         }
     }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -264,6 +264,7 @@ impl InlayId {
     }
 }
 
+pub enum DebugCurrentRowHighlight {}
 enum DiffRowHighlight {}
 enum DocumentHighlightRead {}
 enum DocumentHighlightWrite {}

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1871,7 +1871,11 @@ impl Editor {
             None
         };
 
-        let dap_store = project.as_ref().map(|project| project.read(cx).dap_store());
+        let dap_store = if mode == EditorMode::Full {
+            project.as_ref().map(|project| project.read(cx).dap_store())
+        } else {
+            None
+        };
 
         let mut this = Self {
             focus_handle,

--- a/crates/project/src/buffer_store.rs
+++ b/crates/project/src/buffer_store.rs
@@ -121,7 +121,7 @@ impl BufferStore {
         let buffer = self.get_by_path(&project_path, cx);
         if let Some(existing_buffer) = buffer {
             self.dap_store.update(cx, |store, cx| {
-                store.set_active_breakpoints(&project_path, &existing_buffer.read(cx));
+                store.on_open_buffer(&project_path, &existing_buffer, cx);
             });
             return Task::ready(Ok(existing_buffer));
         }
@@ -162,7 +162,7 @@ impl BufferStore {
                         let buffer = load_result.map_err(Arc::new)?;
 
                         this.dap_store.update(cx, |store, cx| {
-                            store.set_active_breakpoints(&project_path, buffer.read(cx));
+                            store.on_open_buffer(&project_path, &buffer, cx);
                         });
 
                         Ok(buffer)


### PR DESCRIPTION
This PR adds the followings:
- Switching between debug tabs will show the active debug file for that thread
- Show current debug when you reopen a file