### PR TITLE
Cleanup adapters code and add javascript adapter

### DIFF
--- a/crates/dap/src/adapters.rs
+++ b/crates/dap/src/adapters.rs
@@ -24,10 +24,10 @@ use std::{
     time::Duration,
 };
 
-use task::TCPHost;
+use task::{DebugAdapterConfig, TCPHost};
 
 /// Get an open port to use with the tcp client when not supplied by debug config
-async fn get_port(host: Ipv4Addr) -> Option<u16> {
+async fn get_open_port(host: Ipv4Addr) -> Option<u16> {
     Some(
         TcpListener::bind(SocketAddrV4::new(host, 0))
             .await
@@ -51,25 +51,25 @@ pub trait DapDelegate {
 /// - `cx`: The context that the new client belongs too
 pub async fn create_tcp_client(
     host: TCPHost,
-    adapter_binary: DebugAdapterBinary,
+    adapter_binary: &DebugAdapterBinary,
     cx: &mut AsyncAppContext,
 ) -> Result<TransportParams> {
     let host_address = host.host.unwrap_or_else(|| Ipv4Addr::new(127, 0, 0, 1));
 
     let mut port = host.port;
     if port.is_none() {
-        port = get_port(host_address).await;
+        port = get_open_port(host_address).await;
     }
     let mut command = if let Some(start_command) = &adapter_binary.start_command {
         let mut command = process::Command::new(start_command);
-        command.arg(adapter_binary.path);
+        command.arg(adapter_binary.path.clone());
         command
     } else {
-        process::Command::new(adapter_binary.path)
+        process::Command::new(adapter_binary.path.clone())
     };
 
     command
-        .args(adapter_binary.arguments)
+        .args(adapter_binary.arguments.clone())
         .envs(adapter_binary.env.clone().unwrap_or_default())
         .stdin(Stdio::null())
         .stdout(Stdio::null())
@@ -108,18 +108,18 @@ pub async fn create_tcp_client(
 ///
 /// # Parameters
 /// - `adapter_binary`: The debug adapter binary to start
-pub fn create_stdio_client(adapter_binary: DebugAdapterBinary) -> Result<TransportParams> {
+pub fn create_stdio_client(adapter_binary: &DebugAdapterBinary) -> Result<TransportParams> {
     let mut command = if let Some(start_command) = &adapter_binary.start_command {
         let mut command = process::Command::new(start_command);
-        command.arg(adapter_binary.path);
+        command.arg(adapter_binary.path.clone());
         command
     } else {
-        let command = process::Command::new(adapter_binary.path);
+        let command = process::Command::new(adapter_binary.path.clone());
         command
     };
 
     command
-        .args(adapter_binary.arguments)
+        .args(adapter_binary.arguments.clone())
         .envs(adapter_binary.env.clone().unwrap_or_default())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -176,23 +176,32 @@ pub struct DebugAdapterBinary {
 }
 
 #[async_trait(?Send)]
-pub trait DebugAdapter: Debug + Send + Sync + 'static {
+pub trait DebugAdapter: 'static + Send + Sync {
     fn id(&self) -> String {
         "".to_string()
     }
 
     fn name(&self) -> DebugAdapterName;
 
+    /// The `initialize_args` could be used to determine the port/host for tcp connections
     async fn connect(
         &self,
-        adapter_binary: DebugAdapterBinary,
+        adapter_binary: &DebugAdapterBinary,
+        initialize_args: &serde_json::Value,
         cx: &mut AsyncAppContext,
     ) -> anyhow::Result<TransportParams>;
 
-    async fn install_or_fetch_binary(
+    /// Installs the binary for the debug adapter.
+    /// This method is called when the adapter binary is not found or needs to be updated.
+    /// It should download and install the necessary files for the debug adapter to function.
+    async fn install_binary(&self, delegate: &dyn DapDelegate) -> Result<()>;
+
+    async fn fetch_binary(
         &self,
-        delegate: Box<dyn DapDelegate>,
+        delegate: &dyn DapDelegate,
+        config: &DebugAdapterConfig,
     ) -> Result<DebugAdapterBinary>;
 
-    fn request_args(&self) -> Value;
+    /// Should return base configuration to make the debug adapter work
+    fn request_args(&self, config: &DebugAdapterConfig) -> Value;
 }

--- a/crates/dap/src/adapters.rs
+++ b/crates/dap/src/adapters.rs
@@ -183,11 +183,9 @@ pub trait DebugAdapter: 'static + Send + Sync {
 
     fn name(&self) -> DebugAdapterName;
 
-    /// The `initialize_args` could be used to determine the port/host for tcp connections
     async fn connect(
         &self,
         adapter_binary: &DebugAdapterBinary,
-        initialize_args: &serde_json::Value,
         cx: &mut AsyncAppContext,
     ) -> anyhow::Result<TransportParams>;
 

--- a/crates/dap_adapters/src/custom.rs
+++ b/crates/dap_adapters/src/custom.rs
@@ -25,7 +25,6 @@ impl DebugAdapter for CustomDebugAdapter {
     async fn connect(
         &self,
         adapter_binary: &DebugAdapterBinary,
-        _: &Value,
         cx: &mut AsyncAppContext,
     ) -> Result<TransportParams> {
         match &self.custom_args.connection {

--- a/crates/dap_adapters/src/custom.rs
+++ b/crates/dap_adapters/src/custom.rs
@@ -1,23 +1,18 @@
+use serde_json::Value;
+use task::DebugAdapterConfig;
+
 use crate::*;
 
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub(crate) struct CustomDebugAdapter {
-    start_command: String,
-    initialize_args: Option<serde_json::Value>,
-    program: String,
-    connection: DebugConnectionType,
+    custom_args: CustomArgs,
 }
 
 impl CustomDebugAdapter {
     const _ADAPTER_NAME: &'static str = "custom_dap";
 
-    pub(crate) fn new(adapter_config: &DebugAdapterConfig, custom_args: CustomArgs) -> Self {
-        CustomDebugAdapter {
-            start_command: custom_args.start_command,
-            program: adapter_config.program.clone(),
-            connection: custom_args.connection,
-            initialize_args: adapter_config.initialize_args.clone(),
-        }
+    pub(crate) fn new(custom_args: CustomArgs) -> Self {
+        CustomDebugAdapter { custom_args }
     }
 }
 
@@ -29,10 +24,11 @@ impl DebugAdapter for CustomDebugAdapter {
 
     async fn connect(
         &self,
-        adapter_binary: DebugAdapterBinary,
+        adapter_binary: &DebugAdapterBinary,
+        _: &Value,
         cx: &mut AsyncAppContext,
     ) -> Result<TransportParams> {
-        match &self.connection {
+        match &self.custom_args.connection {
             DebugConnectionType::STDIO => create_stdio_client(adapter_binary),
             DebugConnectionType::TCP(tcp_host) => {
                 create_tcp_client(tcp_host.clone(), adapter_binary, cx).await
@@ -40,24 +36,19 @@ impl DebugAdapter for CustomDebugAdapter {
         }
     }
 
-    async fn install_or_fetch_binary(
-        &self,
-        _delegate: Box<dyn DapDelegate>,
-    ) -> Result<DebugAdapterBinary> {
-        bail!("Install or fetch not implemented for custom debug adapter (yet)");
+    fn request_args(&self, config: &DebugAdapterConfig) -> Value {
+        json!({"program": config.program})
     }
 
-    fn request_args(&self) -> Value {
-        let base_args = json!({
-            "program": format!("{}", &self.program)
-        });
+    async fn install_binary(&self, _: &dyn DapDelegate) -> Result<()> {
+        bail!("Install or fetch not implemented for custom debug adapter (yet)")
+    }
 
-        // TODO Debugger: Figure out a way to combine this with base args
-        // if let Some(args) = &self.initialize_args {
-        //     let args = json!(args.clone()).as_object().into_iter();
-        //     base_args.as_object_mut().unwrap().extend(args);
-        // }
-
-        base_args
+    async fn fetch_binary(
+        &self,
+        _: &dyn DapDelegate,
+        _: &DebugAdapterConfig,
+    ) -> Result<DebugAdapterBinary> {
+        bail!("Install or fetch not implemented for custom debug adapter (yet)")
     }
 }

--- a/crates/dap_adapters/src/dap_adapters.rs
+++ b/crates/dap_adapters/src/dap_adapters.rs
@@ -30,12 +30,11 @@ use task::{CustomArgs, DebugAdapterConfig, DebugAdapterKind, DebugConnectionType
 
 pub fn build_adapter(adapter_config: &DebugAdapterConfig) -> Result<Box<dyn DebugAdapter>> {
     match &adapter_config.kind {
-        DebugAdapterKind::Custom(start_args) => Ok(Box::new(CustomDebugAdapter::new(
-            adapter_config,
-            start_args.clone(),
-        ))),
-        DebugAdapterKind::Python => Ok(Box::new(PythonDebugAdapter::new(adapter_config))),
-        DebugAdapterKind::PHP => Ok(Box::new(PhpDebugAdapter::new(adapter_config))),
-        DebugAdapterKind::Lldb => Ok(Box::new(LldbDebugAdapter::new(adapter_config))),
+        DebugAdapterKind::Custom(start_args) => {
+            Ok(Box::new(CustomDebugAdapter::new(start_args.clone())))
+        }
+        DebugAdapterKind::Python => Ok(Box::new(PythonDebugAdapter::new())),
+        DebugAdapterKind::PHP => Ok(Box::new(PhpDebugAdapter::new())),
+        DebugAdapterKind::Lldb => Ok(Box::new(LldbDebugAdapter::new())),
     }
 }

--- a/crates/dap_adapters/src/dap_adapters.rs
+++ b/crates/dap_adapters/src/dap_adapters.rs
@@ -5,6 +5,7 @@ mod php;
 mod python;
 
 use custom::CustomDebugAdapter;
+use javascript::JsDebugAdapter;
 use lldb::LldbDebugAdapter;
 use php::PhpDebugAdapter;
 use python::PythonDebugAdapter;
@@ -35,6 +36,7 @@ pub fn build_adapter(adapter_config: &DebugAdapterConfig) -> Result<Box<dyn Debu
         }
         DebugAdapterKind::Python => Ok(Box::new(PythonDebugAdapter::new())),
         DebugAdapterKind::PHP => Ok(Box::new(PhpDebugAdapter::new())),
+        DebugAdapterKind::Javascript => Ok(Box::new(JsDebugAdapter::new())),
         DebugAdapterKind::Lldb => Ok(Box::new(LldbDebugAdapter::new())),
     }
 }

--- a/crates/dap_adapters/src/javascript.rs
+++ b/crates/dap_adapters/src/javascript.rs
@@ -151,17 +151,17 @@ impl DebugAdapter for JsDebugAdapter {
                     .output()
                     .await?;
 
-                let _npm = delegate
+                let _ = delegate
                     .node_runtime()
                     .ok_or(anyhow!("Couldn't get npm runtime"))?
                     .run_npm_subcommand(&adapter_path, "install", &[])
                     .await
                     .ok();
 
-                let _npm = delegate
+                let _ = delegate
                     .node_runtime()
                     .ok_or(anyhow!("Couldn't get npm runtime"))?
-                    .run_npm_subcommand(&adapter_path, "compile", &[])
+                    .run_npm_subcommand(&adapter_path, "run", &["compile"])
                     .await
                     .ok();
 

--- a/crates/dap_adapters/src/javascript.rs
+++ b/crates/dap_adapters/src/javascript.rs
@@ -176,9 +176,6 @@ impl DebugAdapter for JsDebugAdapter {
         json!({
             "program": config.program,
             "type": "pwa-node",
-            "request": "launch",
-            "sourceMaps": true,
-            "skipFiles": ["**/node_modules/**"],
         })
     }
 }

--- a/crates/dap_adapters/src/javascript.rs
+++ b/crates/dap_adapters/src/javascript.rs
@@ -36,12 +36,22 @@ impl DebugAdapter for JsDebugAdapter {
 
     async fn fetch_binary(
         &self,
-        _: &dyn DapDelegate,
+        delegate: &dyn DapDelegate,
         config: &DebugAdapterConfig,
     ) -> Result<DebugAdapterBinary> {
+        let node_runtime = delegate
+            .node_runtime()
+            .ok_or(anyhow!("Couldn't get npm runtime"))?;
+
         if let Some(adapter_path) = config.adapter_path.as_ref() {
             return Ok(DebugAdapterBinary {
-                start_command: Some("node".into()),
+                start_command: Some(
+                    node_runtime
+                        .binary_path()
+                        .await?
+                        .to_string_lossy()
+                        .into_owned(),
+                ),
                 path: std::path::PathBuf::from_str(adapter_path)?,
                 arguments: vec!["8133".into()],
                 env: None,
@@ -51,7 +61,13 @@ impl DebugAdapter for JsDebugAdapter {
         let adapter_path = paths::debug_adapters_dir().join(self.name());
 
         Ok(DebugAdapterBinary {
-            start_command: Some("node".into()),
+            start_command: Some(
+                node_runtime
+                    .binary_path()
+                    .await?
+                    .to_string_lossy()
+                    .into_owned(),
+            ),
             path: adapter_path.join(Self::ADAPTER_PATH),
             arguments: vec!["8133".into()],
             env: None,

--- a/crates/dap_adapters/src/javascript.rs
+++ b/crates/dap_adapters/src/javascript.rs
@@ -22,7 +22,6 @@ impl DebugAdapter for JsDebugAdapter {
     async fn connect(
         &self,
         adapter_binary: &DebugAdapterBinary,
-        _: &Value,
         cx: &mut AsyncAppContext,
     ) -> Result<TransportParams> {
         let host = TCPHost {

--- a/crates/dap_adapters/src/javascript.rs
+++ b/crates/dap_adapters/src/javascript.rs
@@ -1,1 +1,169 @@
+use crate::*;
+use std::str::FromStr;
 
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub(crate) struct JsDebugAdapter {}
+
+impl JsDebugAdapter {
+    const ADAPTER_NAME: &'static str = "vscode-js-debug";
+    const ADAPTER_PATH: &'static str = "src/dapDebugServer.js";
+
+    pub(crate) fn new() -> Self {
+        JsDebugAdapter {}
+    }
+}
+
+#[async_trait(?Send)]
+impl DebugAdapter for JsDebugAdapter {
+    fn name(&self) -> DebugAdapterName {
+        DebugAdapterName(Self::ADAPTER_NAME.into())
+    }
+
+    async fn connect(
+        &self,
+        adapter_binary: &DebugAdapterBinary,
+        _: &Value,
+        cx: &mut AsyncAppContext,
+    ) -> Result<TransportParams> {
+        let host = TCPHost {
+            port: Some(8133),
+            host: None,
+            delay: Some(1000),
+        };
+
+        create_tcp_client(host, adapter_binary, cx).await
+    }
+
+    async fn fetch_binary(
+        &self,
+        _: &dyn DapDelegate,
+        config: &DebugAdapterConfig,
+    ) -> Result<DebugAdapterBinary> {
+        if let Some(adapter_path) = config.adapter_path.as_ref() {
+            return Ok(DebugAdapterBinary {
+                start_command: Some("node".into()),
+                path: std::path::PathBuf::from_str(adapter_path)?,
+                arguments: vec!["8133".into()],
+                env: None,
+            });
+        }
+
+        let adapter_path = paths::debug_adapters_dir().join(self.name());
+
+        Ok(DebugAdapterBinary {
+            start_command: Some("node".into()),
+            path: adapter_path.join(Self::ADAPTER_PATH),
+            arguments: vec!["8133".into()],
+            env: None,
+        })
+    }
+
+    async fn install_binary(&self, delegate: &dyn DapDelegate) -> Result<()> {
+        let adapter_path = paths::debug_adapters_dir().join(self.name());
+        let fs = delegate.fs();
+
+        if fs.is_dir(adapter_path.as_path()).await {
+            return Ok(());
+        }
+
+        if let Some(http_client) = delegate.http_client() {
+            if !adapter_path.exists() {
+                fs.create_dir(&adapter_path.as_path()).await?;
+            }
+
+            let release = latest_github_release(
+                "microsoft/vscode-js-debug",
+                false,
+                false,
+                http_client.clone(),
+            )
+            .await?;
+
+            let asset_name = format!("{}-{}", self.name(), release.tag_name);
+            let zip_path = adapter_path.join(asset_name);
+
+            if fs::metadata(&zip_path).await.is_err() {
+                let mut response = http_client
+                    .get(&release.zipball_url, Default::default(), true)
+                    .await
+                    .context("Error downloading release")?;
+
+                let mut file = File::create(&zip_path).await?;
+                futures::io::copy(response.body_mut(), &mut file).await?;
+
+                let _unzip_status = process::Command::new("unzip")
+                    .current_dir(&adapter_path)
+                    .arg(&zip_path)
+                    .output()
+                    .await?
+                    .status;
+
+                let mut ls = process::Command::new("ls")
+                    .current_dir(&adapter_path)
+                    .stdout(Stdio::piped())
+                    .spawn()?;
+
+                let std = ls
+                    .stdout
+                    .take()
+                    .ok_or(anyhow!("Failed to list directories"))?
+                    .into_stdio()
+                    .await?;
+
+                let file_name = String::from_utf8(
+                    process::Command::new("grep")
+                        .arg("microsoft-vscode-js-debug")
+                        .stdin(std)
+                        .output()
+                        .await?
+                        .stdout,
+                )?;
+
+                let file_name = file_name.trim_end();
+
+                process::Command::new("sh")
+                    .current_dir(&adapter_path)
+                    .arg("-c")
+                    .arg(format!("mv {file_name}/* ."))
+                    .output()
+                    .await?;
+
+                process::Command::new("rm")
+                    .current_dir(&adapter_path)
+                    .arg("-rf")
+                    .arg(file_name)
+                    .arg(zip_path)
+                    .output()
+                    .await?;
+
+                let _npm = delegate
+                    .node_runtime()
+                    .ok_or(anyhow!("Couldn't get npm runtime"))?
+                    .run_npm_subcommand(&adapter_path, "install", &[])
+                    .await
+                    .ok();
+
+                let _npm = delegate
+                    .node_runtime()
+                    .ok_or(anyhow!("Couldn't get npm runtime"))?
+                    .run_npm_subcommand(&adapter_path, "compile", &[])
+                    .await
+                    .ok();
+
+                return Ok(());
+            }
+        }
+
+        bail!("Install or fetch not implemented for Javascript debug adapter (yet)");
+    }
+
+    fn request_args(&self, config: &DebugAdapterConfig) -> Value {
+        json!({
+            "program": config.program,
+            "type": "pwa-node",
+            "request": "launch",
+            "sourceMaps": true,
+            "skipFiles": ["**/node_modules/**"],
+        })
+    }
+}

--- a/crates/dap_adapters/src/lldb.rs
+++ b/crates/dap_adapters/src/lldb.rs
@@ -24,7 +24,6 @@ impl DebugAdapter for LldbDebugAdapter {
     async fn connect(
         &self,
         adapter_binary: &DebugAdapterBinary,
-        _: &Value,
         _: &mut AsyncAppContext,
     ) -> Result<TransportParams> {
         create_stdio_client(adapter_binary)

--- a/crates/dap_adapters/src/lldb.rs
+++ b/crates/dap_adapters/src/lldb.rs
@@ -42,7 +42,7 @@ impl DebugAdapter for LldbDebugAdapter {
         bail!("Install or fetch not implemented for lldb debug adapter (yet)")
     }
 
-    fn request_args(&self, _: &DebugAdapterConfig) -> Value {
-        Value::default()
+    fn request_args(&self, config: &DebugAdapterConfig) -> Value {
+        json!({"program": config.program})
     }
 }

--- a/crates/dap_adapters/src/lldb.rs
+++ b/crates/dap_adapters/src/lldb.rs
@@ -1,19 +1,17 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use task::DebugAdapterConfig;
+
 use crate::*;
 
 #[derive(Debug, Eq, PartialEq, Clone)]
-pub(crate) struct LldbDebugAdapter {
-    program: String,
-    adapter_path: Option<String>,
-}
+pub(crate) struct LldbDebugAdapter {}
 
 impl LldbDebugAdapter {
     const _ADAPTER_NAME: &'static str = "lldb";
 
-    pub(crate) fn new(adapter_config: &DebugAdapterConfig) -> Self {
-        LldbDebugAdapter {
-            program: adapter_config.program.clone(),
-            adapter_path: adapter_config.adapter_path.clone(),
-        }
+    pub(crate) fn new() -> Self {
+        LldbDebugAdapter {}
     }
 }
 
@@ -25,20 +23,26 @@ impl DebugAdapter for LldbDebugAdapter {
 
     async fn connect(
         &self,
-        adapter_binary: DebugAdapterBinary,
+        adapter_binary: &DebugAdapterBinary,
+        _: &Value,
         _: &mut AsyncAppContext,
     ) -> Result<TransportParams> {
         create_stdio_client(adapter_binary)
     }
 
-    async fn install_or_fetch_binary(
-        &self,
-        _delegate: Box<dyn DapDelegate>,
-    ) -> Result<DebugAdapterBinary> {
-        bail!("Install or fetch binary not implemented for lldb debug adapter (yet)");
+    async fn install_binary(&self, _: &dyn DapDelegate) -> Result<()> {
+        bail!("Install or fetch not implemented for lldb debug adapter (yet)")
     }
 
-    fn request_args(&self) -> Value {
-        json!({"program": format!("{}", &self.program)})
+    async fn fetch_binary(
+        &self,
+        _: &dyn DapDelegate,
+        _: &DebugAdapterConfig,
+    ) -> Result<DebugAdapterBinary> {
+        bail!("Install or fetch not implemented for lldb debug adapter (yet)")
+    }
+
+    fn request_args(&self, _: &DebugAdapterConfig) -> Value {
+        Value::default()
     }
 }

--- a/crates/dap_adapters/src/php.rs
+++ b/crates/dap_adapters/src/php.rs
@@ -3,19 +3,14 @@ use std::str::FromStr;
 use crate::*;
 
 #[derive(Debug, Eq, PartialEq, Clone)]
-pub(crate) struct PhpDebugAdapter {
-    program: String,
-    adapter_path: Option<String>,
-}
+pub(crate) struct PhpDebugAdapter {}
 
 impl PhpDebugAdapter {
     const ADAPTER_NAME: &'static str = "vscode-php-debug";
+    const ADAPTER_PATH: &'static str = "out/phpDebug.js";
 
-    pub(crate) fn new(adapter_config: &DebugAdapterConfig) -> Self {
-        PhpDebugAdapter {
-            program: adapter_config.program.clone(),
-            adapter_path: adapter_config.adapter_path.clone(),
-        }
+    pub(crate) fn new() -> Self {
+        PhpDebugAdapter {}
     }
 }
 
@@ -27,7 +22,8 @@ impl DebugAdapter for PhpDebugAdapter {
 
     async fn connect(
         &self,
-        adapter_binary: DebugAdapterBinary,
+        adapter_binary: &DebugAdapterBinary,
+        _: &Value,
         cx: &mut AsyncAppContext,
     ) -> Result<TransportParams> {
         let host = TCPHost {
@@ -39,11 +35,12 @@ impl DebugAdapter for PhpDebugAdapter {
         create_tcp_client(host, adapter_binary, cx).await
     }
 
-    async fn install_or_fetch_binary(
+    async fn fetch_binary(
         &self,
-        delegate: Box<dyn DapDelegate>,
+        _: &dyn DapDelegate,
+        config: &DebugAdapterConfig,
     ) -> Result<DebugAdapterBinary> {
-        if let Some(adapter_path) = self.adapter_path.as_ref() {
+        if let Some(adapter_path) = config.adapter_path.as_ref() {
             return Ok(DebugAdapterBinary {
                 start_command: Some("bun".into()),
                 path: std::path::PathBuf::from_str(adapter_path)?,
@@ -53,16 +50,24 @@ impl DebugAdapter for PhpDebugAdapter {
         }
 
         let adapter_path = paths::debug_adapters_dir().join(self.name());
+
+        Ok(DebugAdapterBinary {
+            start_command: Some("bun".into()),
+            path: adapter_path.join(Self::ADAPTER_PATH),
+            arguments: vec!["--server=8132".into()],
+            env: None,
+        })
+    }
+
+    async fn install_binary(&self, delegate: &dyn DapDelegate) -> Result<()> {
+        let adapter_path = paths::debug_adapters_dir().join(self.name());
         let fs = delegate.fs();
 
         if fs.is_dir(adapter_path.as_path()).await {
-            return Ok(DebugAdapterBinary {
-                start_command: Some("bun".into()),
-                path: adapter_path.join("out/phpDebug.js"),
-                arguments: vec!["--server=8132".into()],
-                env: None,
-            });
-        } else if let Some(http_client) = delegate.http_client() {
+            return Ok(());
+        }
+
+        if let Some(http_client) = delegate.http_client() {
             if !adapter_path.exists() {
                 fs.create_dir(&adapter_path.as_path()).await?;
             }
@@ -142,19 +147,14 @@ impl DebugAdapter for PhpDebugAdapter {
                     .await
                     .is_ok();
 
-                return Ok(DebugAdapterBinary {
-                    start_command: Some("bun".into()),
-                    path: adapter_path.join("out/phpDebug.js"),
-                    arguments: vec!["--server=8132".into()],
-                    env: None,
-                });
+                return Ok(());
             }
         }
 
-        bail!("Install or fetch not implemented for Php debug adapter (yet)");
+        bail!("Install or fetch not implemented for PHP debug adapter (yet)");
     }
 
-    fn request_args(&self) -> Value {
-        json!({"program": format!("{}", &self.program)})
+    fn request_args(&self, config: &DebugAdapterConfig) -> Value {
+        json!({"program": config.program})
     }
 }

--- a/crates/dap_adapters/src/php.rs
+++ b/crates/dap_adapters/src/php.rs
@@ -158,7 +158,7 @@ impl DebugAdapter for PhpDebugAdapter {
                 let _ = delegate
                     .node_runtime()
                     .ok_or(anyhow!("Couldn't get npm runtime"))?
-                    .run_npm_subcommand(&adapter_path, "build", &[])
+                    .run_npm_subcommand(&adapter_path, "run", &["build"])
                     .await
                     .is_ok();
 

--- a/crates/dap_adapters/src/php.rs
+++ b/crates/dap_adapters/src/php.rs
@@ -23,7 +23,6 @@ impl DebugAdapter for PhpDebugAdapter {
     async fn connect(
         &self,
         adapter_binary: &DebugAdapterBinary,
-        _: &Value,
         cx: &mut AsyncAppContext,
     ) -> Result<TransportParams> {
         let host = TCPHost {

--- a/crates/dap_adapters/src/python.rs
+++ b/crates/dap_adapters/src/python.rs
@@ -3,19 +3,14 @@ use std::str::FromStr;
 use crate::*;
 
 #[derive(Debug, Eq, PartialEq, Clone)]
-pub(crate) struct PythonDebugAdapter {
-    program: String,
-    adapter_path: Option<String>,
-}
+pub(crate) struct PythonDebugAdapter {}
 
 impl PythonDebugAdapter {
     const ADAPTER_NAME: &'static str = "debugpy";
+    const ADAPTER_PATH: &'static str = "src/debugpy/adapter";
 
-    pub(crate) fn new(adapter_config: &DebugAdapterConfig) -> Self {
-        PythonDebugAdapter {
-            program: adapter_config.program.clone(),
-            adapter_path: adapter_config.adapter_path.clone(),
-        }
+    pub(crate) fn new() -> Self {
+        PythonDebugAdapter {}
     }
 }
 
@@ -27,20 +22,19 @@ impl DebugAdapter for PythonDebugAdapter {
 
     async fn connect(
         &self,
-        adapter_binary: DebugAdapterBinary,
-        _cx: &mut AsyncAppContext,
+        adapter_binary: &DebugAdapterBinary,
+        _: &Value,
+        _: &mut AsyncAppContext,
     ) -> Result<TransportParams> {
         create_stdio_client(adapter_binary)
     }
 
-    async fn install_or_fetch_binary(
+    async fn fetch_binary(
         &self,
-        delegate: Box<dyn DapDelegate>,
+        _: &dyn DapDelegate,
+        config: &DebugAdapterConfig,
     ) -> Result<DebugAdapterBinary> {
-        let adapter_path = paths::debug_adapters_dir().join("debugpy/src/debugpy/adapter");
-        let fs = delegate.fs();
-
-        if let Some(adapter_path) = self.adapter_path.as_ref() {
+        if let Some(adapter_path) = config.adapter_path.as_ref() {
             return Ok(DebugAdapterBinary {
                 start_command: Some("python3".to_string()),
                 path: std::path::PathBuf::from_str(&adapter_path)?,
@@ -49,14 +43,25 @@ impl DebugAdapter for PythonDebugAdapter {
             });
         }
 
+        let adapter_path = paths::debug_adapters_dir().join(self.name());
+
+        Ok(DebugAdapterBinary {
+            start_command: Some("python3".to_string()),
+            path: adapter_path.join(Self::ADAPTER_PATH),
+            arguments: vec![],
+            env: None,
+        })
+    }
+
+    async fn install_binary(&self, delegate: &dyn DapDelegate) -> Result<()> {
+        let adapter_path = paths::debug_adapters_dir().join(self.name());
+        let fs = delegate.fs();
+
         if fs.is_dir(adapter_path.as_path()).await {
-            return Ok(DebugAdapterBinary {
-                start_command: Some("python3".to_string()),
-                path: adapter_path,
-                arguments: vec![],
-                env: None,
-            });
-        } else if let Some(http_client) = delegate.http_client() {
+            return Ok(());
+        }
+
+        if let Some(http_client) = delegate.http_client() {
             let debugpy_dir = paths::debug_adapters_dir().join("debugpy");
 
             if !debugpy_dir.exists() {
@@ -123,22 +128,14 @@ impl DebugAdapter for PythonDebugAdapter {
                     .output()
                     .await?;
 
-                return Ok(DebugAdapterBinary {
-                    start_command: Some("python3".to_string()),
-                    path: adapter_path,
-                    arguments: vec![],
-                    env: None,
-                });
+                return Ok(());
             }
-            return Err(anyhow!("Failed to download debugpy"));
-        } else {
-            return Err(anyhow!(
-                "Could not find debugpy in paths or connect to http"
-            ));
         }
+
+        bail!("Install or fetch not implemented for Python debug adapter (yet)");
     }
 
-    fn request_args(&self) -> Value {
-        json!({"program": format!("{}", &self.program)})
+    fn request_args(&self, config: &DebugAdapterConfig) -> Value {
+        json!({"program": config.program})
     }
 }

--- a/crates/dap_adapters/src/python.rs
+++ b/crates/dap_adapters/src/python.rs
@@ -23,7 +23,6 @@ impl DebugAdapter for PythonDebugAdapter {
     async fn connect(
         &self,
         adapter_binary: &DebugAdapterBinary,
-        _: &Value,
         _: &mut AsyncAppContext,
     ) -> Result<TransportParams> {
         create_stdio_client(adapter_binary)

--- a/crates/project/src/dap_store.rs
+++ b/crates/project/src/dap_store.rs
@@ -272,10 +272,7 @@ impl DapStore {
                 merge_json_value_into(args.configuration, &mut request_args);
             }
 
-            let transport_params = adapter
-                .connect(&binary, &request_args, &mut cx)
-                .await
-                .log_err()?;
+            let transport_params = adapter.connect(&binary, &mut cx).await.log_err()?;
 
             let client = DebugAdapterClient::new(
                 client_id,

--- a/crates/project/src/dap_store.rs
+++ b/crates/project/src/dap_store.rs
@@ -237,11 +237,11 @@ impl DapStore {
         cx: &mut ModelContext<Self>,
     ) {
         let client_id = self.next_client_id();
-        let adapter_delegate = Box::new(DapAdapterDelegate::new(
+        let adapter_delegate = DapAdapterDelegate::new(
             self.http_client.clone(),
             self.node_runtime.clone(),
             self.fs.clone(),
-        ));
+        );
         let start_client_task = cx.spawn(|this, mut cx| async move {
             let dap_store = this.clone();
             let adapter = Arc::new(
@@ -249,23 +249,33 @@ impl DapStore {
                     .context("Creating debug adapter")
                     .log_err()?,
             );
+            let _ = adapter
+                .install_binary(&adapter_delegate)
+                .await
+                .context("Failed to install debug adapter binary")
+                .log_err()?;
+
             let binary = adapter
-                .install_or_fetch_binary(adapter_delegate)
+                .fetch_binary(&adapter_delegate, &config)
                 .await
                 .context("Failed to get debug adapter binary")
                 .log_err()?;
-            let transport_params = adapter.connect(binary, &mut cx).await.log_err()?;
 
             let mut request_args = json!({});
             if let Some(config_args) = config.initialize_args.clone() {
                 merge_json_value_into(config_args, &mut request_args);
             }
 
-            merge_json_value_into(adapter.request_args(), &mut request_args);
+            merge_json_value_into(adapter.request_args(&config), &mut request_args);
 
             if let Some(args) = args {
                 merge_json_value_into(args.configuration, &mut request_args);
             }
+
+            let transport_params = adapter
+                .connect(&binary, &request_args, &mut cx)
+                .await
+                .log_err()?;
 
             let client = DebugAdapterClient::new(
                 client_id,

--- a/crates/task/src/debug_format.rs
+++ b/crates/task/src/debug_format.rs
@@ -44,6 +44,8 @@ pub enum DebugAdapterKind {
     Python,
     /// Use vscode-php-debug
     PHP,
+    /// Use vscode-js-debug
+    Javascript,
     /// Use lldb
     Lldb,
 }


### PR DESCRIPTION
This PR cleans up the adapters code, the code for installing/fetching a binary is now in 2 separate methods for the Separation of Concerns. It's also more streamlined how the adapter should be implemented.

This PR also adds the JavaScript debug adapter, which I will work on right after this PR. 

cc @Anthony-Eid 


To tests JavaScript debugging, you need to have the following task:

```json
{
	"label": "Javascript Debug file",
	"command": "Javascript Debug file",
	"task_type": {
		"type": "debug",
		"kind": "javascript",
		"program": "/Users/remcosmits/Documents/code/prettier-test/test.js",
		"request": "launch",
		"initialize_args": {
			"cwd": "/Users/remcosmits/Documents/code/prettier-test" // This is required for now, later the adapter will insert this.
		}
	}
}
```

**Note**:
Debugging JavaScript only works if you pass in a program, I will work on making the other reverse requests work, so we can support more ways how you can debug JavaScript.