### PR TITLE
Debug terminal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3468,6 +3468,7 @@ name = "debugger_ui"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "collections",
  "dap",
  "editor",
  "futures 0.3.30",
@@ -3482,6 +3483,7 @@ dependencies = [
  "settings",
  "task",
  "tasks_ui",
+ "terminal_view",
  "theme",
  "ui",
  "workspace",

--- a/crates/dap/src/client.rs
+++ b/crates/dap/src/client.rs
@@ -180,6 +180,14 @@ impl DebugAdapterClient {
         }
     }
 
+    pub async fn respond(&self, response: Response) -> Result<()> {
+        self.transport
+            .server_tx
+            .send(Message::Response(response))
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to send response: {}", e))
+    }
+
     pub fn id(&self) -> DebugAdapterClientId {
         self.id
     }

--- a/crates/dap_adapters/src/javascript.rs
+++ b/crates/dap_adapters/src/javascript.rs
@@ -160,10 +160,6 @@ impl DebugAdapter for JsDebugAdapter {
         json!({
             "program": config.program,
             "type": "pwa-node",
-            "skipFiles": [
-                "<node_internals>/**",
-                "**/node_modules/**"
-            ]
         })
     }
 }

--- a/crates/debugger_ui/Cargo.toml
+++ b/crates/debugger_ui/Cargo.toml
@@ -10,6 +10,7 @@ workspace = true
 
 [dependencies]
 anyhow.workspace = true
+collections.workspace = true
 dap.workspace = true
 editor.workspace = true
 futures.workspace = true
@@ -24,6 +25,7 @@ serde_json.workspace = true
 settings.workspace = true
 task.workspace = true
 tasks_ui.workspace = true
+terminal_view.workspace = true
 theme.workspace = true
 ui.workspace = true
 workspace.workspace = true

--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -1,15 +1,14 @@
 use crate::debugger_panel_item::DebugPanelItem;
 use anyhow::Result;
 use collections::{BTreeMap, HashMap};
-use dap::client::DebugAdapterClient;
 use dap::client::{DebugAdapterClientId, ThreadStatus};
 use dap::debugger_settings::DebuggerSettings;
-use dap::messages::{Events, Message, Response};
+use dap::messages::{Events, Message};
 use dap::requests::{Request, RunInTerminal, StartDebugging};
 use dap::{
-    Capabilities, CapabilitiesEvent, ContinuedEvent, ErrorResponse, ExitedEvent, LoadedSourceEvent,
-    ModuleEvent, OutputEvent, RunInTerminalRequestArguments, RunInTerminalResponse, StoppedEvent,
-    TerminatedEvent, ThreadEvent, ThreadEventReason,
+    Capabilities, CapabilitiesEvent, ContinuedEvent, ExitedEvent, LoadedSourceEvent, ModuleEvent,
+    OutputEvent, RunInTerminalRequestArguments, StoppedEvent, TerminatedEvent, ThreadEvent,
+    ThreadEventReason,
 };
 use gpui::{
     actions, Action, AppContext, AsyncWindowContext, EventEmitter, FocusHandle, FocusableView,
@@ -20,7 +19,6 @@ use project::terminals::TerminalKind;
 use serde_json::Value;
 use settings::Settings;
 use std::path::PathBuf;
-use std::sync::Arc;
 use std::u64;
 use terminal_view::terminal_panel::TerminalPanel;
 use ui::prelude::*;
@@ -96,34 +94,29 @@ impl DebugPanel {
                 cx.subscribe(&pane, Self::handle_pane_event),
                 cx.subscribe(&project, {
                     move |this: &mut Self, _, event, cx| match event {
-                        project::Event::DebugClientEvent { message, client_id } => {
-                            let Some(client) = this.debug_client_by_id(client_id, cx) else {
-                                return cx.emit(DebugPanelEvent::ClientStopped(*client_id));
-                            };
-
-                            match message {
-                                Message::Event(event) => {
-                                    this.handle_debug_client_events(client_id, event, cx);
-                                }
-                                Message::Request(request) => {
-                                    if StartDebugging::COMMAND == request.command {
-                                        this.handle_start_debugging_request(
-                                            client,
-                                            request.arguments.clone(),
-                                            cx,
-                                        );
-                                    } else if RunInTerminal::COMMAND == request.command {
-                                        this.handle_run_in_terminal_request(
-                                            client,
-                                            request.seq,
-                                            request.arguments.clone(),
-                                            cx,
-                                        );
-                                    }
-                                }
-                                _ => unreachable!(),
+                        project::Event::DebugClientEvent { message, client_id } => match message {
+                            Message::Event(event) => {
+                                this.handle_debug_client_events(client_id, event, cx);
                             }
-                        }
+                            Message::Request(request) => {
+                                if StartDebugging::COMMAND == request.command {
+                                    this.handle_start_debugging_request(
+                                        client_id,
+                                        request.seq,
+                                        request.arguments.clone(),
+                                        cx,
+                                    );
+                                } else if RunInTerminal::COMMAND == request.command {
+                                    this.handle_run_in_terminal_request(
+                                        client_id,
+                                        request.seq,
+                                        request.arguments.clone(),
+                                        cx,
+                                    );
+                                }
+                            }
+                            _ => unreachable!(),
+                        },
                         project::Event::DebugClientStopped(client_id) => {
                             cx.emit(DebugPanelEvent::ClientStopped(*client_id));
 
@@ -167,23 +160,6 @@ impl DebugPanel {
             .read(cx)
             .active_item()
             .and_then(|panel| panel.downcast::<DebugPanelItem>())
-    }
-
-    fn debug_client_by_id(
-        &self,
-        client_id: &DebugAdapterClientId,
-        cx: &mut ViewContext<Self>,
-    ) -> Option<Arc<DebugAdapterClient>> {
-        self.workspace
-            .update(cx, |this, cx| {
-                this.project()
-                    .read(cx)
-                    .dap_store()
-                    .read(cx)
-                    .client_by_id(client_id)
-            })
-            .ok()
-            .flatten()
     }
 
     fn handle_pane_event(
@@ -238,29 +214,38 @@ impl DebugPanel {
 
     fn handle_start_debugging_request(
         &mut self,
-        client: Arc<DebugAdapterClient>,
+        client_id: &DebugAdapterClientId,
+        seq: u64,
         request_args: Option<Value>,
         cx: &mut ViewContext<Self>,
     ) {
-        let start_args = if let Some(args) = request_args {
+        let args = if let Some(args) = request_args {
             serde_json::from_value(args.clone()).ok()
         } else {
             None
         };
 
         self.dap_store.update(cx, |store, cx| {
-            store.start_client(client.config(), start_args, cx);
+            store
+                .respond_to_start_debugging(client_id, seq, args, cx)
+                .detach_and_log_err(cx);
         });
     }
 
     fn handle_run_in_terminal_request(
         &mut self,
-        client: Arc<DebugAdapterClient>,
+        client_id: &DebugAdapterClientId,
         seq: u64,
         request_args: Option<Value>,
         cx: &mut ViewContext<Self>,
     ) {
         let Some(request_args) = request_args else {
+            self.dap_store.update(cx, |store, cx| {
+                store
+                    .respond_to_run_in_terminal(client_id, false, seq, None, cx)
+                    .detach_and_log_err(cx);
+            });
+
             return;
         };
 
@@ -288,74 +273,73 @@ impl DebugPanel {
             }
         }
 
-        let _ = self.workspace.update(cx, |workspace, cx| {
-            if let Some(terminal_panel) = workspace.panel::<TerminalPanel>(cx) {
-                terminal_panel.update(cx, |terminal_panel, cx| {
-                    let mut args = request_args.args.clone();
+        let terminal_task = self.workspace.update(cx, |workspace, cx| {
+            let terminal_panel = workspace.panel::<TerminalPanel>(cx).unwrap();
 
-                    // Handle special case for NodeJS debug adapter
-                    // If only the Node binary path is provided, we set the command to None
-                    // This prevents the NodeJS REPL from appearing, which is not the desired behavior
-                    // The expected usage is for users to provide their own Node command, e.g., `node test.js`
-                    // This allows the NodeJS debug client to attach correctly
-                    let command = if args.len() > 1 {
-                        Some(args.remove(0))
-                    } else {
-                        None
+            terminal_panel.update(cx, |terminal_panel, cx| {
+                let mut args = request_args.args.clone();
+
+                // Handle special case for NodeJS debug adapter
+                // If only the Node binary path is provided, we set the command to None
+                // This prevents the NodeJS REPL from appearing, which is not the desired behavior
+                // The expected usage is for users to provide their own Node command, e.g., `node test.js`
+                // This allows the NodeJS debug client to attach correctly
+                let command = if args.len() > 1 {
+                    Some(args.remove(0))
+                } else {
+                    None
+                };
+
+                let terminal_task = terminal_panel.add_terminal(
+                    TerminalKind::Debug {
+                        command,
+                        args,
+                        envs,
+                        cwd: PathBuf::from(request_args.cwd),
+                    },
+                    task::RevealStrategy::Always,
+                    cx,
+                );
+
+                cx.spawn(|_, mut cx| async move {
+                    let pid_task = async move {
+                        let terminal = terminal_task.await?;
+
+                        terminal.read_with(&mut cx, |terminal, _| terminal.pty_info.pid())
                     };
 
-                    let terminal_task = terminal_panel.add_terminal(
-                        TerminalKind::Debug {
-                            command,
-                            args,
-                            envs,
-                            cwd: PathBuf::from(request_args.cwd),
-                        },
-                        task::RevealStrategy::Always,
-                        cx,
-                    );
-
-                    cx.spawn(|_, mut cx| async move {
-                        let pid = async move {
-                            let terminal = terminal_task.await?;
-
-                            terminal.read_with(&mut cx, |terminal, _| terminal.pty_info.pid())
-                        };
-
-                        match pid.await {
-                            Ok(pid) => {
-                                client
-                                    .respond(Response {
-                                        seq,
-                                        request_seq: seq,
-                                        success: true,
-                                        command: RunInTerminal::COMMAND.to_string(),
-                                        body: Some(serde_json::to_value(RunInTerminalResponse {
-                                            process_id: Some(std::process::id() as u64),
-                                            shell_process_id: pid.map(|pid| pid.as_u32() as u64),
-                                        })?),
-                                    })
-                                    .await
-                            }
-                            Err(_) => {
-                                return client
-                                    .respond(Response {
-                                        seq,
-                                        request_seq: seq,
-                                        success: false,
-                                        command: RunInTerminal::COMMAND.to_string(),
-                                        body: Some(serde_json::to_value(ErrorResponse {
-                                            error: None,
-                                        })?),
-                                    })
-                                    .await
-                            }
-                        }
-                    })
-                    .detach_and_log_err(cx);
-                });
-            }
+                    pid_task.await
+                })
+            })
         });
+
+        let client_id = client_id.clone();
+        cx.spawn(|this, mut cx| async move {
+            // Ensure a response is always sent, even in error cases,
+            // to maintain proper communication with the debug adapter
+            let (success, pid) = match terminal_task {
+                Ok(pid_task) => match pid_task.await {
+                    Ok(pid) => (true, pid.clone()),
+                    Err(_) => (false, None),
+                },
+                Err(_) => (false, None),
+            };
+
+            let respond_task = this.update(&mut cx, |this, cx| {
+                this.dap_store.update(cx, |store, cx| {
+                    store.respond_to_run_in_terminal(
+                        &client_id,
+                        success,
+                        seq,
+                        pid.map(|pid| pid.as_u32() as u64),
+                        cx,
+                    )
+                })
+            });
+
+            respond_task?.await
+        })
+        .detach_and_log_err(cx);
     }
 
     fn handle_debug_client_events(

--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -313,13 +313,13 @@ impl DebugPanel {
             })
         });
 
-        let client_id = client_id.clone();
+        let client_id = *client_id;
         cx.spawn(|this, mut cx| async move {
             // Ensure a response is always sent, even in error cases,
             // to maintain proper communication with the debug adapter
             let (success, pid) = match terminal_task {
                 Ok(pid_task) => match pid_task.await {
-                    Ok(pid) => (true, pid.clone()),
+                    Ok(pid) => (true, pid),
                     Err(_) => (false, None),
                 },
                 Err(_) => (false, None),

--- a/crates/project/src/dap_store.rs
+++ b/crates/project/src/dap_store.rs
@@ -334,14 +334,14 @@ impl DapStore {
                     path_format: Some(InitializeRequestArgumentsPathFormat::Path),
                     supports_variable_type: Some(true),
                     supports_variable_paging: Some(false),
-                    supports_run_in_terminal_request: Some(false),
+                    supports_run_in_terminal_request: Some(true),
                     supports_memory_references: Some(true),
                     supports_progress_reporting: Some(false),
                     supports_invalidated_event: Some(false),
                     lines_start_at1: Some(false),
                     columns_start_at1: Some(false),
                     supports_memory_event: Some(false),
-                    supports_args_can_be_interpreted_by_shell: Some(true),
+                    supports_args_can_be_interpreted_by_shell: Some(false),
                     supports_start_debugging_request: Some(true),
                 })
                 .await?;

--- a/crates/project/src/dap_store.rs
+++ b/crates/project/src/dap_store.rs
@@ -2,18 +2,19 @@ use crate::ProjectPath;
 use anyhow::{anyhow, Context as _, Result};
 use collections::{HashMap, HashSet};
 use dap::client::{DebugAdapterClient, DebugAdapterClientId};
-use dap::messages::Message;
+use dap::messages::{Message, Response};
 use dap::requests::{
     Attach, Completions, ConfigurationDone, Continue, Disconnect, Evaluate, Initialize, Launch,
-    LoadedSources, Modules, Next, Pause, Scopes, SetBreakpoints, SetExpression, SetVariable,
-    StackTrace, StepIn, StepOut, Terminate, TerminateThreads, Variables,
+    LoadedSources, Modules, Next, Pause, Request as _, RunInTerminal, Scopes, SetBreakpoints,
+    SetExpression, SetVariable, StackTrace, StartDebugging, StepIn, StepOut, Terminate,
+    TerminateThreads, Variables,
 };
 use dap::{
     AttachRequestArguments, Capabilities, CompletionItem, CompletionsArguments,
-    ConfigurationDoneArguments, ContinueArguments, DisconnectArguments, EvaluateArguments,
-    EvaluateArgumentsContext, EvaluateResponse, InitializeRequestArguments,
+    ConfigurationDoneArguments, ContinueArguments, DisconnectArguments, ErrorResponse,
+    EvaluateArguments, EvaluateArgumentsContext, EvaluateResponse, InitializeRequestArguments,
     InitializeRequestArgumentsPathFormat, LaunchRequestArguments, LoadedSourcesArguments, Module,
-    ModulesArguments, NextArguments, PauseArguments, Scope, ScopesArguments,
+    ModulesArguments, NextArguments, PauseArguments, RunInTerminalResponse, Scope, ScopesArguments,
     SetBreakpointsArguments, SetExpressionArguments, SetVariableArguments, Source,
     SourceBreakpoint, StackFrame, StackTraceArguments, StartDebuggingRequestArguments,
     StepInArguments, StepOutArguments, SteppingGranularity, TerminateArguments,
@@ -491,6 +492,74 @@ impl DapStore {
                     .await
             } else {
                 Ok(())
+            }
+        })
+    }
+
+    pub fn respond_to_start_debugging(
+        &self,
+        client_id: &DebugAdapterClientId,
+        seq: u64,
+        args: Option<StartDebuggingRequestArguments>,
+        cx: &mut ModelContext<Self>,
+    ) -> Task<Result<()>> {
+        let Some(client) = self.client_by_id(client_id) else {
+            return Task::ready(Err(anyhow!("Could not found client")));
+        };
+
+        cx.spawn(|this, mut cx| async move {
+            client
+                .respond(Message::Response(Response {
+                    seq,
+                    request_seq: seq,
+                    success: true,
+                    command: StartDebugging::COMMAND.to_string(),
+                    body: None,
+                }))
+                .await?;
+
+            this.update(&mut cx, |store, cx| {
+                store.start_client(client.config(), args, cx);
+            })
+        })
+    }
+
+    pub fn respond_to_run_in_terminal(
+        &self,
+        client_id: &DebugAdapterClientId,
+        success: bool,
+        seq: u64,
+        shell_pid: Option<u64>,
+        cx: &mut ModelContext<Self>,
+    ) -> Task<Result<()>> {
+        let Some(client) = self.client_by_id(client_id) else {
+            return Task::ready(Err(anyhow!("Could not found client")));
+        };
+
+        cx.spawn(|_, _| async move {
+            if success {
+                client
+                    .respond(Message::Response(Response {
+                        seq,
+                        request_seq: seq,
+                        success: true,
+                        command: RunInTerminal::COMMAND.to_string(),
+                        body: Some(serde_json::to_value(RunInTerminalResponse {
+                            process_id: Some(std::process::id() as u64),
+                            shell_process_id: shell_pid,
+                        })?),
+                    }))
+                    .await
+            } else {
+                client
+                    .respond(Message::Response(Response {
+                        seq,
+                        request_seq: seq,
+                        success: false,
+                        command: RunInTerminal::COMMAND.to_string(),
+                        body: Some(serde_json::to_value(ErrorResponse { error: None })?),
+                    }))
+                    .await
             }
         })
     }

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -144,6 +144,8 @@ impl Project {
             .and_then(|path| self.python_venv_directory(path, settings, cx));
         let mut python_venv_activate_command = None;
 
+        let debug_terminal = matches!(kind, TerminalKind::Debug { .. });
+
         let (spawn_task, shell) = match kind {
             TerminalKind::Shell(_) => {
                 if let Some(python_venv_directory) = python_venv_directory {
@@ -248,6 +250,7 @@ impl Project {
             settings.max_scroll_history_lines,
             window,
             completion_tx,
+            debug_terminal,
             cx,
         )
         .map(|builder| {

--- a/crates/task/src/debug_format.rs
+++ b/crates/task/src/debug_format.rs
@@ -78,7 +78,7 @@ pub struct DebugAdapterConfig {
     #[serde(default)]
     pub request: DebugRequestType,
     /// The program that you trying to debug
-    pub program: String,
+    pub program: Option<String>,
     /// Additional initialization arguments to be sent on DAP initialization
     pub initialize_args: Option<serde_json::Value>,
 }
@@ -99,7 +99,7 @@ pub struct DebugTaskDefinition {
     /// Name of the debug tasks
     label: String,
     /// Program to run the debugger on
-    program: String,
+    program: Option<String>,
     /// Launch | Request depending on the session the adapter should be ran as
     #[serde(default)]
     session_type: DebugRequestType,

--- a/crates/task/src/lib.rs
+++ b/crates/task/src/lib.rs
@@ -99,13 +99,12 @@ impl ResolvedTask {
         match self.original_task.task_type.clone() {
             TaskType::Script => None,
             TaskType::Debug(mut adapter_config) => {
-                adapter_config.program = match &self.resolved {
+                let program = match &self.resolved {
                     None => adapter_config.program,
-                    Some(spawn_in_terminal) => spawn_in_terminal
-                        .program
-                        .clone()
-                        .unwrap_or(adapter_config.program),
+                    Some(spawn_in_terminal) => spawn_in_terminal.program.clone(),
                 };
+
+                adapter_config.program = program;
                 Some(adapter_config)
             }
         }

--- a/crates/task/src/task_template.rs
+++ b/crates/task/src/task_template.rs
@@ -94,7 +94,7 @@ mod deserialization_tests {
         let adapter_config = DebugAdapterConfig {
             kind: DebugAdapterKind::Python,
             request: crate::DebugRequestType::Launch,
-            program: "main".to_string(),
+            program: Some("main".to_string()),
             initialize_args: None,
         };
         let json = json!({
@@ -243,12 +243,18 @@ impl TaskTemplate {
 
         let program = match &self.task_type {
             TaskType::Script => None,
-            TaskType::Debug(adapter_config) => Some(substitute_all_template_variables_in_str(
-                &adapter_config.program,
-                &task_variables,
-                &variable_names,
-                &mut substituted_variables,
-            )?),
+            TaskType::Debug(adapter_config) => {
+                if let Some(program) = &adapter_config.program {
+                    Some(substitute_all_template_variables_in_str(
+                        program,
+                        &task_variables,
+                        &variable_names,
+                        &mut substituted_variables,
+                    )?)
+                } else {
+                    None
+                }
+            }
         };
 
         let task_hash = to_hex_hash(self)

--- a/crates/terminal/src/pty_info.rs
+++ b/crates/terminal/src/pty_info.rs
@@ -142,4 +142,8 @@ impl PtyProcessInfo {
         }
         has_changed
     }
+
+    pub fn pid(&self) -> Option<Pid> {
+        self.pid_getter.pid()
+    }
 }

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -330,6 +330,7 @@ impl TerminalBuilder {
         max_scroll_history_lines: Option<usize>,
         window: AnyWindowHandle,
         completion_tx: Sender<()>,
+        debug_terminal: bool,
         cx: &AppContext,
     ) -> Result<TerminalBuilder> {
         // If the parent environment doesn't have a locale set
@@ -457,6 +458,7 @@ impl TerminalBuilder {
             url_regex: RegexSearch::new(URL_REGEX).unwrap(),
             word_regex: RegexSearch::new(WORD_REGEX).unwrap(),
             vi_mode_enabled: false,
+            debug_terminal,
         };
 
         Ok(TerminalBuilder {
@@ -613,6 +615,7 @@ pub struct Terminal {
     word_regex: RegexSearch,
     task: Option<TaskState>,
     vi_mode_enabled: bool,
+    debug_terminal: bool,
 }
 
 pub struct TaskState {
@@ -1680,6 +1683,10 @@ impl Terminal {
 
     pub fn task(&self) -> Option<&TaskState> {
         self.task.as_ref()
+    }
+
+    pub fn debug_terminal(&self) -> bool {
+        self.debug_terminal
     }
 
     pub fn wait_for_completed_task(&self, cx: &AppContext) -> Task<()> {

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -620,7 +620,9 @@ impl TerminalPanel {
             .items()
             .filter_map(|item| {
                 let terminal_view = item.act_as::<TerminalView>(cx)?;
-                if terminal_view.read(cx).terminal().read(cx).task().is_some() {
+                let terminal = terminal_view.read(cx).terminal().read(cx);
+
+                if terminal.task().is_some() || terminal.debug_terminal() {
                     None
                 } else {
                     let id = item.item_id().as_u64();

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -564,7 +564,7 @@ impl TerminalPanel {
         })
     }
 
-    fn add_terminal(
+    pub fn add_terminal(
         &mut self,
         kind: TerminalKind,
         reveal_strategy: RevealStrategy,


### PR DESCRIPTION
This PR introduces an innovative debugging feature in **Zed** called the **Debug Terminal**.

### How it works:
When you initiate a debug session, we respond to a `runInTerminal` reverse request by launching a terminal with specified parameters, including `envs` and optional `args`. This allows for direct program execution within the newly opened terminal and allows you to modify any env variables before each time you execute the program that you are trying to debug.

For instance, during a JavaScript debug session, entering `node my_program.js` prompts the JavaScript debug adapter to automatically attach itself. This seamless integration is possible because the adapter is aware of both the process ID of your active Zed application and the spawned terminal.


### Configuration:

#### Debug terminal for JavaScript
```json
{
  "label": "JavaScript Debug Terminal",
  "command": "JavaScript Debug Terminal",
  "task_type": {
    "type": "debug",
    "kind": "javascript",
    "request": "launch",
    "initialize_args": {
      "console": "integratedTerminal",
      "cwd": "/Users/remcosmits/Documents/code/prettier-test", // This is required for now, later the adapter will insert this.
    }
  }
}
```

### Example:

https://github.com/user-attachments/assets/c4deff07-80dd-4dc6-ad2e-0c252a478fe9

/cc @Anthony-Eid I made the `program` value optional inside the **DebugTaskDefinition**