### PR TITLE
Move how we connect to an debug adpater to the transport layer

### DIFF
--- a/crates/dap/src/adapters.rs
+++ b/crates/dap/src/adapters.rs
@@ -1,156 +1,18 @@
-use crate::client::TransportParams;
+use crate::transport::Transport;
 use ::fs::Fs;
-use anyhow::{anyhow, Context, Result};
+use anyhow::Result;
 use async_trait::async_trait;
-use futures::AsyncReadExt;
-use gpui::AsyncAppContext;
 use http_client::HttpClient;
 use node_runtime::NodeRuntime;
 use serde_json::Value;
-use smol::{
-    self,
-    io::BufReader,
-    net::{TcpListener, TcpStream},
-    process,
-};
-use std::{
-    collections::HashMap,
-    ffi::OsString,
-    fmt::Debug,
-    net::{Ipv4Addr, SocketAddrV4},
-    path::Path,
-    process::Stdio,
-    sync::Arc,
-    time::Duration,
-};
+use std::{collections::HashMap, ffi::OsString, path::Path, sync::Arc};
 
-use task::{DebugAdapterConfig, TCPHost};
-
-/// Get an open port to use with the tcp client when not supplied by debug config
-async fn get_open_port(host: Ipv4Addr) -> Option<u16> {
-    Some(
-        TcpListener::bind(SocketAddrV4::new(host, 0))
-            .await
-            .ok()?
-            .local_addr()
-            .ok()?
-            .port(),
-    )
-}
+use task::DebugAdapterConfig;
 
 pub trait DapDelegate {
     fn http_client(&self) -> Option<Arc<dyn HttpClient>>;
     fn node_runtime(&self) -> Option<NodeRuntime>;
     fn fs(&self) -> Arc<dyn Fs>;
-}
-
-/// TCP clients don't have an error communication stream with an adapter
-/// # Parameters
-/// - `host`: The ip/port that that the client will connect too
-/// - `adapter_binary`: The debug adapter binary to start
-/// - `cx`: The context that the new client belongs too
-pub async fn create_tcp_client(
-    host: TCPHost,
-    adapter_binary: &DebugAdapterBinary,
-    cx: &mut AsyncAppContext,
-) -> Result<TransportParams> {
-    let host_address = host.host.unwrap_or_else(|| Ipv4Addr::new(127, 0, 0, 1));
-
-    let mut port = host.port;
-    if port.is_none() {
-        port = get_open_port(host_address).await;
-    }
-
-    let mut command = process::Command::new(&adapter_binary.command);
-
-    if let Some(args) = &adapter_binary.arguments {
-        command.args(args);
-    }
-
-    if let Some(envs) = &adapter_binary.envs {
-        command.envs(envs);
-    }
-
-    command
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .kill_on_drop(true);
-
-    let process = command
-        .spawn()
-        .with_context(|| "failed to start debug adapter.")?;
-
-    if let Some(delay) = host.delay {
-        // some debug adapters need some time to start the TCP server
-        // so we have to wait few milliseconds before we can connect to it
-        cx.background_executor()
-            .timer(Duration::from_millis(delay))
-            .await;
-    }
-
-    let address = SocketAddrV4::new(
-        host_address,
-        port.ok_or(anyhow!("Port is required to connect to TCP server"))?,
-    );
-
-    let (rx, tx) = TcpStream::connect(address).await?.split();
-    log::info!("Debug adapter has connected to tcp server");
-
-    Ok(TransportParams::new(
-        Box::new(BufReader::new(rx)),
-        Box::new(tx),
-        None,
-        Some(process),
-    ))
-}
-
-/// Creates a debug client that connects to an adapter through std input/output
-///
-/// # Parameters
-/// - `adapter_binary`: The debug adapter binary to start
-pub fn create_stdio_client(adapter_binary: &DebugAdapterBinary) -> Result<TransportParams> {
-    let mut command = process::Command::new(&adapter_binary.command);
-
-    if let Some(args) = &adapter_binary.arguments {
-        command.args(args);
-    }
-
-    if let Some(envs) = &adapter_binary.envs {
-        command.envs(envs);
-    }
-
-    command
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .kill_on_drop(true);
-
-    let mut process = command
-        .spawn()
-        .with_context(|| "failed to spawn command.")?;
-
-    let stdin = process
-        .stdin
-        .take()
-        .ok_or_else(|| anyhow!("Failed to open stdin"))?;
-    let stdout = process
-        .stdout
-        .take()
-        .ok_or_else(|| anyhow!("Failed to open stdout"))?;
-    let stderr = process
-        .stderr
-        .take()
-        .ok_or_else(|| anyhow!("Failed to open stderr"))?;
-
-    log::info!("Debug adapter has connected to stdio adapter");
-
-    Ok(TransportParams::new(
-        Box::new(BufReader::new(stdout)),
-        Box::new(stdin),
-        Some(Box::new(BufReader::new(stderr))),
-        Some(process),
-    ))
 }
 
 pub struct DebugAdapterName(pub Arc<str>);
@@ -176,17 +38,9 @@ pub struct DebugAdapterBinary {
 
 #[async_trait(?Send)]
 pub trait DebugAdapter: 'static + Send + Sync {
-    fn id(&self) -> String {
-        "".to_string()
-    }
-
     fn name(&self) -> DebugAdapterName;
 
-    async fn connect(
-        &self,
-        adapter_binary: &DebugAdapterBinary,
-        cx: &mut AsyncAppContext,
-    ) -> anyhow::Result<TransportParams>;
+    fn transport(&self) -> Box<dyn Transport>;
 
     /// Installs the binary for the debug adapter.
     /// This method is called when the adapter binary is not found or needs to be updated.

--- a/crates/dap/src/transport.rs
+++ b/crates/dap/src/transport.rs
@@ -253,29 +253,26 @@ impl TransportDelegate {
     }
 
     pub async fn shutdown(&self) -> Result<()> {
-        async move {
-            if let Some(server_tx) = self.server_tx.as_ref() {
-                server_tx.close();
-            }
-
-            let mut adapter = self.process.lock().await.take();
-            let mut current_requests = self.current_requests.lock().await;
-            let mut pending_requests = self.pending_requests.lock().await;
-
-            current_requests.clear();
-            pending_requests.clear();
-
-            if let Some(mut adapter) = adapter.take() {
-                adapter.kill()?;
-            }
-
-            drop(current_requests);
-            drop(pending_requests);
-            drop(adapter);
-
-            anyhow::Ok(())
+        if let Some(server_tx) = self.server_tx.as_ref() {
+            server_tx.close();
         }
-        .await
+
+        let mut adapter = self.process.lock().await.take();
+        let mut current_requests = self.current_requests.lock().await;
+        let mut pending_requests = self.pending_requests.lock().await;
+
+        current_requests.clear();
+        pending_requests.clear();
+
+        if let Some(mut adapter) = adapter.take() {
+            adapter.kill()?;
+        }
+
+        drop(current_requests);
+        drop(pending_requests);
+        drop(adapter);
+
+        anyhow::Ok(())
     }
 }
 

--- a/crates/dap/src/transport.rs
+++ b/crates/dap/src/transport.rs
@@ -1,68 +1,215 @@
 use anyhow::{anyhow, Context, Result};
+use async_trait::async_trait;
 use dap_types::{
     messages::{Message, Response},
     ErrorResponse,
 };
-use futures::{AsyncBufRead, AsyncWrite};
+use futures::{AsyncBufRead, AsyncReadExt as _, AsyncWrite};
 use gpui::AsyncAppContext;
 use smol::{
     channel::{unbounded, Receiver, Sender},
-    io::{AsyncBufReadExt as _, AsyncReadExt as _, AsyncWriteExt},
+    io::{AsyncBufReadExt as _, AsyncWriteExt, BufReader},
     lock::Mutex,
+    net::{TcpListener, TcpStream},
+    process::{self, Child},
 };
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    borrow::BorrowMut,
+    collections::HashMap,
+    net::{Ipv4Addr, SocketAddrV4},
+    process::Stdio,
+    sync::Arc,
+    time::Duration,
+};
+use task::TCPHost;
 
-#[derive(Debug)]
-pub struct Transport {
-    pub server_tx: Sender<Message>,
-    pub server_rx: Receiver<Message>,
-    pub current_requests: Arc<Mutex<HashMap<u64, Sender<Result<Response>>>>>,
-    pub pending_requests: Arc<Mutex<HashMap<u64, Sender<Result<Response>>>>>,
+use crate::adapters::DebugAdapterBinary;
+
+pub struct TransportParams {
+    input: Box<dyn AsyncWrite + Unpin + Send>,
+    output: Box<dyn AsyncBufRead + Unpin + Send>,
+    error: Box<dyn AsyncBufRead + Unpin + Send>,
+    process: Child,
 }
 
-impl Transport {
-    pub fn start(
-        server_stdout: Box<dyn AsyncBufRead + Unpin + Send>,
-        server_stdin: Box<dyn AsyncWrite + Unpin + Send>,
-        server_stderr: Option<Box<dyn AsyncBufRead + Unpin + Send>>,
+impl TransportParams {
+    pub fn new(
+        input: Box<dyn AsyncWrite + Unpin + Send>,
+        output: Box<dyn AsyncBufRead + Unpin + Send>,
+        error: Box<dyn AsyncBufRead + Unpin + Send>,
+        process: Child,
+    ) -> Self {
+        TransportParams {
+            input,
+            output,
+            error,
+            process,
+        }
+    }
+}
+
+type Requests = Arc<Mutex<HashMap<u64, Sender<Result<Response>>>>>;
+
+pub(crate) struct TransportDelegate {
+    current_requests: Requests,
+    pending_requests: Requests,
+    transport: Box<dyn Transport>,
+    process: Arc<Mutex<Option<Child>>>,
+    server_tx: Option<Sender<Message>>,
+}
+
+impl TransportDelegate {
+    pub fn new(transport: Box<dyn Transport>) -> Self {
+        Self {
+            transport,
+            server_tx: None,
+            process: Default::default(),
+            current_requests: Default::default(),
+            pending_requests: Default::default(),
+        }
+    }
+
+    pub(crate) async fn start(
+        &mut self,
+        binary: &DebugAdapterBinary,
         cx: &mut AsyncAppContext,
-    ) -> Arc<Self> {
+    ) -> Result<(Receiver<Message>, Sender<Message>)> {
+        let params = self.transport.start(binary, cx).await?;
+
         let (client_tx, server_rx) = unbounded::<Message>();
         let (server_tx, client_rx) = unbounded::<Message>();
 
-        let current_requests = Arc::new(Mutex::new(HashMap::default()));
-        let pending_requests = Arc::new(Mutex::new(HashMap::default()));
+        self.process = Arc::new(Mutex::new(Some(params.process)));
+        self.server_tx = Some(server_tx.clone());
 
         cx.background_executor()
-            .spawn(Self::receive(
-                pending_requests.clone(),
-                server_stdout,
+            .spawn(Self::handle_output(
+                params.output,
                 client_tx,
+                self.pending_requests.clone(),
             ))
             .detach();
-
-        if let Some(stderr) = server_stderr {
-            cx.background_executor().spawn(Self::err(stderr)).detach();
-        }
 
         cx.background_executor()
-            .spawn(Self::send(
-                current_requests.clone(),
-                pending_requests.clone(),
-                server_stdin,
+            .spawn(Self::handle_error(params.error))
+            .detach();
+
+        cx.background_executor()
+            .spawn(Self::handle_input(
+                params.input,
                 client_rx,
+                self.current_requests.clone(),
+                self.pending_requests.clone(),
             ))
             .detach();
 
-        Arc::new(Self {
-            server_rx,
-            server_tx,
-            current_requests,
-            pending_requests,
-        })
+        Ok((server_rx, server_tx))
     }
 
-    async fn recv_server_message(
+    pub(crate) async fn add_pending_request(
+        &self,
+        sequence_id: u64,
+        request: Sender<Result<Response>>,
+    ) {
+        let mut pending_requests = self.pending_requests.lock().await;
+        pending_requests.insert(sequence_id, request);
+    }
+
+    pub(crate) async fn send_message(&self, message: Message) -> Result<()> {
+        if let Some(server_tx) = self.server_tx.as_ref() {
+            server_tx
+                .send(message)
+                .await
+                .map_err(|e| anyhow!("Failed to send response back: {}", e))
+        } else {
+            Err(anyhow!("Server tx already dropped"))
+        }
+    }
+
+    async fn handle_input(
+        mut server_stdin: Box<dyn AsyncWrite + Unpin + Send>,
+        client_rx: Receiver<Message>,
+        current_requests: Requests,
+        pending_requests: Requests,
+    ) -> Result<()> {
+        while let Ok(mut payload) = client_rx.recv().await {
+            if let Message::Request(request) = payload.borrow_mut() {
+                if let Some(sender) = current_requests.lock().await.remove(&request.seq) {
+                    pending_requests.lock().await.insert(request.seq, sender);
+                }
+            }
+
+            let message = serde_json::to_string(&payload)?;
+
+            server_stdin
+                .write_all(
+                    format!("Content-Length: {}\r\n\r\n{}", message.len(), message).as_bytes(),
+                )
+                .await?;
+
+            server_stdin.flush().await?;
+        }
+
+        Ok(())
+    }
+
+    async fn handle_output(
+        mut server_stdout: Box<dyn AsyncBufRead + Unpin + Send>,
+        client_tx: Sender<Message>,
+        pending_requests: Requests,
+    ) -> Result<()> {
+        let mut recv_buffer = String::new();
+
+        while let Ok(message) =
+            Self::receive_server_message(&mut server_stdout, &mut recv_buffer).await
+        {
+            match message {
+                Message::Response(res) => {
+                    if let Some(tx) = pending_requests.lock().await.remove(&res.request_seq) {
+                        tx.send(Self::process_response(res)).await?;
+                    } else {
+                        client_tx.send(Message::Response(res)).await?;
+                    };
+                }
+                Message::Request(_) => {
+                    client_tx.send(message).await?;
+                }
+                Message::Event(_) => {
+                    client_tx.send(message).await?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn handle_error(mut stderr: Box<dyn AsyncBufRead + Unpin + Send>) -> Result<()> {
+        let mut buffer = String::new();
+        loop {
+            buffer.truncate(0);
+            if stderr.read_line(&mut buffer).await? == 0 {
+                return Err(anyhow!("debugger error stream closed"));
+            }
+        }
+    }
+
+    fn process_response(response: Response) -> Result<Response> {
+        if response.success {
+            Ok(response)
+        } else {
+            if let Some(body) = response.body {
+                if let Ok(error) = serde_json::from_value::<ErrorResponse>(body) {
+                    if let Some(message) = error.error {
+                        return Err(anyhow!(message.format));
+                    };
+                };
+            }
+
+            Err(anyhow!("Received error response from adapter"))
+        }
+    }
+
+    async fn receive_server_message(
         reader: &mut Box<dyn AsyncBufRead + Unpin + Send>,
         buffer: &mut String,
     ) -> Result<Message> {
@@ -105,122 +252,186 @@ impl Transport {
         Ok(serde_json::from_str::<Message>(msg)?)
     }
 
-    async fn recv_server_error(
-        err: &mut (impl AsyncBufRead + Unpin + Send),
-        buffer: &mut String,
-    ) -> Result<()> {
-        buffer.truncate(0);
-        if err.read_line(buffer).await? == 0 {
-            return Err(anyhow!("debugger error stream closed"));
-        };
-
-        Ok(())
-    }
-
-    async fn send_payload_to_server(
-        current_requests: &Mutex<HashMap<u64, Sender<Result<Response>>>>,
-        pending_requests: &Mutex<HashMap<u64, Sender<Result<Response>>>>,
-        server_stdin: &mut Box<dyn AsyncWrite + Unpin + Send>,
-        mut payload: Message,
-    ) -> Result<()> {
-        if let Message::Request(request) = &mut payload {
-            if let Some(sender) = current_requests.lock().await.remove(&request.seq) {
-                pending_requests.lock().await.insert(request.seq, sender);
+    pub async fn shutdown(&self) -> Result<()> {
+        async move {
+            if let Some(server_tx) = self.server_tx.as_ref() {
+                server_tx.close();
             }
+
+            let mut adapter = self.process.lock().await.take();
+            let mut current_requests = self.current_requests.lock().await;
+            let mut pending_requests = self.pending_requests.lock().await;
+
+            current_requests.clear();
+            pending_requests.clear();
+
+            if let Some(mut adapter) = adapter.take() {
+                adapter.kill()?;
+            }
+
+            drop(current_requests);
+            drop(pending_requests);
+            drop(adapter);
+
+            anyhow::Ok(())
         }
-        Self::send_string_to_server(server_stdin, serde_json::to_string(&payload)?).await
+        .await
+    }
+}
+
+#[async_trait(?Send)]
+pub trait Transport: 'static + Send + Sync {
+    async fn start(
+        &mut self,
+        binary: &DebugAdapterBinary,
+        cx: &mut AsyncAppContext,
+    ) -> Result<TransportParams>;
+}
+
+pub struct TcpTransport {
+    config: TCPHost,
+}
+
+impl TcpTransport {
+    pub fn new(config: TCPHost) -> Self {
+        Self { config }
     }
 
-    async fn send_string_to_server(
-        server_stdin: &mut Box<dyn AsyncWrite + Unpin + Send>,
-        request: String,
-    ) -> Result<()> {
-        server_stdin
-            .write_all(format!("Content-Length: {}\r\n\r\n{}", request.len(), request).as_bytes())
-            .await?;
-
-        server_stdin.flush().await?;
-        Ok(())
-    }
-
-    fn process_response(response: Response) -> Result<Response> {
-        if response.success {
-            Ok(response)
-        } else {
-            if let Some(body) = response.body {
-                if let Ok(error) = serde_json::from_value::<ErrorResponse>(body) {
-                    if let Some(message) = error.error {
-                        return Err(anyhow!(message.format));
-                    };
-                };
-            }
-
-            Err(anyhow!("Received error response from adapter"))
-        }
-    }
-
-    async fn process_server_message(
-        pending_requests: &Arc<Mutex<HashMap<u64, Sender<Result<Response>>>>>,
-        client_tx: &Sender<Message>,
-        message: Message,
-    ) -> Result<()> {
-        match message {
-            Message::Response(res) => {
-                if let Some(tx) = pending_requests.lock().await.remove(&res.request_seq) {
-                    tx.send(Self::process_response(res)).await?;
-                } else {
-                    client_tx.send(Message::Response(res)).await?;
-                };
-            }
-            Message::Request(_) => {
-                client_tx.send(message).await?;
-            }
-            Message::Event(_) => {
-                client_tx.send(message).await?;
-            }
-        }
-        Ok(())
-    }
-
-    async fn receive(
-        pending_requests: Arc<Mutex<HashMap<u64, Sender<Result<Response>>>>>,
-        mut server_stdout: Box<dyn AsyncBufRead + Unpin + Send>,
-        client_tx: Sender<Message>,
-    ) -> Result<()> {
-        let mut recv_buffer = String::new();
-
-        while let Ok(msg) = Self::recv_server_message(&mut server_stdout, &mut recv_buffer).await {
-            Self::process_server_message(&pending_requests, &client_tx, msg)
+    /// Get an open port to use with the tcp client when not supplied by debug config
+    async fn get_open_port(host: Ipv4Addr) -> Option<u16> {
+        Some(
+            TcpListener::bind(SocketAddrV4::new(host, 0))
                 .await
-                .context("Process server message failed in transport::receive")?;
-        }
-
-        Ok(())
+                .ok()?
+                .local_addr()
+                .ok()?
+                .port(),
+        )
     }
+}
 
-    async fn send(
-        current_requests: Arc<Mutex<HashMap<u64, Sender<Result<Response>>>>>,
-        pending_requests: Arc<Mutex<HashMap<u64, Sender<Result<Response>>>>>,
-        mut server_stdin: Box<dyn AsyncWrite + Unpin + Send>,
-        client_rx: Receiver<Message>,
-    ) -> Result<()> {
-        while let Ok(payload) = client_rx.recv().await {
-            Self::send_payload_to_server(
-                &current_requests,
-                &pending_requests,
-                &mut server_stdin,
-                payload,
-            )
-            .await?;
+#[async_trait(?Send)]
+impl Transport for TcpTransport {
+    async fn start(
+        &mut self,
+        binary: &DebugAdapterBinary,
+        cx: &mut AsyncAppContext,
+    ) -> Result<TransportParams> {
+        let host_address = self
+            .config
+            .host
+            .unwrap_or_else(|| Ipv4Addr::new(127, 0, 0, 1));
+
+        let mut port = self.config.port;
+        if port.is_none() {
+            port = Self::get_open_port(host_address).await;
         }
 
-        Ok(())
+        let mut command = process::Command::new(&binary.command);
+
+        if let Some(args) = &binary.arguments {
+            command.args(args);
+        }
+
+        if let Some(envs) = &binary.envs {
+            command.envs(envs);
+        }
+
+        command
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+
+        let mut process = command
+            .spawn()
+            .with_context(|| "failed to start debug adapter.")?;
+
+        let stderr = process
+            .stderr
+            .take()
+            .ok_or_else(|| anyhow!("Failed to open stderr"))?;
+
+        if let Some(delay) = self.config.delay {
+            // some debug adapters need some time to start the TCP server
+            // so we have to wait few milliseconds before we can connect to it
+            cx.background_executor()
+                .timer(Duration::from_millis(delay))
+                .await;
+        }
+
+        let address = SocketAddrV4::new(
+            host_address,
+            port.ok_or(anyhow!("Port is required to connect to TCP server"))?,
+        );
+
+        let (rx, tx) = TcpStream::connect(address).await?.split();
+        log::info!("Debug adapter has connected to tcp server");
+
+        Ok(TransportParams::new(
+            Box::new(tx),
+            Box::new(BufReader::new(rx)),
+            Box::new(BufReader::new(stderr)),
+            process,
+        ))
     }
+}
 
-    async fn err(mut server_stderr: Box<dyn AsyncBufRead + Unpin + Send>) -> Result<()> {
-        let mut recv_buffer = String::new();
-        loop {
-            Self::recv_server_error(&mut server_stderr, &mut recv_buffer).await?;
+pub struct StdioTransport {}
+
+impl StdioTransport {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+#[async_trait(?Send)]
+impl Transport for StdioTransport {
+    async fn start(
+        &mut self,
+        binary: &DebugAdapterBinary,
+        _: &mut AsyncAppContext,
+    ) -> Result<TransportParams> {
+        let mut command = process::Command::new(&binary.command);
+
+        if let Some(args) = &binary.arguments {
+            command.args(args);
         }
+
+        if let Some(envs) = &binary.envs {
+            command.envs(envs);
+        }
+
+        command
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+
+        let mut process = command
+            .spawn()
+            .with_context(|| "failed to spawn command.")?;
+
+        let stdin = process
+            .stdin
+            .take()
+            .ok_or_else(|| anyhow!("Failed to open stdin"))?;
+        let stdout = process
+            .stdout
+            .take()
+            .ok_or_else(|| anyhow!("Failed to open stdout"))?;
+        let stderr = process
+            .stderr
+            .take()
+            .ok_or_else(|| anyhow!("Failed to open stderr"))?;
+
+        log::info!("Debug adapter has connected to stdio adapter");
+
+        Ok(TransportParams::new(
+            Box::new(stdin),
+            Box::new(BufReader::new(stdout)),
+            Box::new(BufReader::new(stderr)),
+            process,
+        ))
     }
 }

--- a/crates/dap_adapters/src/custom.rs
+++ b/crates/dap_adapters/src/custom.rs
@@ -1,5 +1,6 @@
 use std::ffi::OsString;
 
+use dap::transport::{StdioTransport, TcpTransport, Transport};
 use serde_json::Value;
 use task::DebugAdapterConfig;
 
@@ -24,16 +25,10 @@ impl DebugAdapter for CustomDebugAdapter {
         DebugAdapterName(Self::ADAPTER_NAME.into())
     }
 
-    async fn connect(
-        &self,
-        adapter_binary: &DebugAdapterBinary,
-        cx: &mut AsyncAppContext,
-    ) -> Result<TransportParams> {
+    fn transport(&self) -> Box<dyn Transport> {
         match &self.custom_args.connection {
-            DebugConnectionType::STDIO => create_stdio_client(adapter_binary),
-            DebugConnectionType::TCP(tcp_host) => {
-                create_tcp_client(tcp_host.clone(), adapter_binary, cx).await
-            }
+            DebugConnectionType::STDIO => Box::new(StdioTransport::new()),
+            DebugConnectionType::TCP(tcp_host) => Box::new(TcpTransport::new(tcp_host.clone())),
         }
     }
 

--- a/crates/dap_adapters/src/dap_adapters.rs
+++ b/crates/dap_adapters/src/dap_adapters.rs
@@ -12,14 +12,7 @@ use python::PythonDebugAdapter;
 
 use anyhow::{anyhow, bail, Context, Result};
 use async_trait::async_trait;
-use dap::{
-    adapters::{
-        create_stdio_client, create_tcp_client, DapDelegate, DebugAdapter, DebugAdapterBinary,
-        DebugAdapterName,
-    },
-    client::TransportParams,
-};
-use gpui::AsyncAppContext;
+use dap::adapters::{DapDelegate, DebugAdapter, DebugAdapterBinary, DebugAdapterName};
 use http_client::github::latest_github_release;
 use serde_json::{json, Value};
 use smol::{

--- a/crates/dap_adapters/src/javascript.rs
+++ b/crates/dap_adapters/src/javascript.rs
@@ -24,7 +24,7 @@ impl DebugAdapter for JsDebugAdapter {
         Box::new(TcpTransport::new(TCPHost {
             port: Some(8133),
             host: None,
-            delay: Some(1000),
+            timeout: None,
         }))
     }
 

--- a/crates/dap_adapters/src/javascript.rs
+++ b/crates/dap_adapters/src/javascript.rs
@@ -1,3 +1,5 @@
+use dap::transport::{TcpTransport, Transport};
+
 use crate::*;
 
 #[derive(Debug, Eq, PartialEq, Clone)]
@@ -18,18 +20,12 @@ impl DebugAdapter for JsDebugAdapter {
         DebugAdapterName(Self::ADAPTER_NAME.into())
     }
 
-    async fn connect(
-        &self,
-        adapter_binary: &DebugAdapterBinary,
-        cx: &mut AsyncAppContext,
-    ) -> Result<TransportParams> {
-        let host = TCPHost {
+    fn transport(&self) -> Box<dyn Transport> {
+        Box::new(TcpTransport::new(TCPHost {
             port: Some(8133),
             host: None,
             delay: Some(1000),
-        };
-
-        create_tcp_client(host, adapter_binary, cx).await
+        }))
     }
 
     async fn fetch_binary(

--- a/crates/dap_adapters/src/lldb.rs
+++ b/crates/dap_adapters/src/lldb.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use async_trait::async_trait;
+use dap::transport::{StdioTransport, Transport};
 use task::DebugAdapterConfig;
 
 use crate::*;
@@ -21,12 +22,8 @@ impl DebugAdapter for LldbDebugAdapter {
         DebugAdapterName(Self::ADAPTER_NAME.into())
     }
 
-    async fn connect(
-        &self,
-        adapter_binary: &DebugAdapterBinary,
-        _: &mut AsyncAppContext,
-    ) -> Result<TransportParams> {
-        create_stdio_client(adapter_binary)
+    fn transport(&self) -> Box<dyn Transport> {
+        Box::new(StdioTransport::new())
     }
 
     async fn install_binary(&self, _: &dyn DapDelegate) -> Result<()> {

--- a/crates/dap_adapters/src/php.rs
+++ b/crates/dap_adapters/src/php.rs
@@ -24,7 +24,7 @@ impl DebugAdapter for PhpDebugAdapter {
         Box::new(TcpTransport::new(TCPHost {
             port: Some(8132),
             host: None,
-            delay: Some(1000),
+            timeout: None,
         }))
     }
 

--- a/crates/dap_adapters/src/php.rs
+++ b/crates/dap_adapters/src/php.rs
@@ -1,3 +1,5 @@
+use dap::transport::{TcpTransport, Transport};
+
 use crate::*;
 
 #[derive(Debug, Eq, PartialEq, Clone)]
@@ -18,18 +20,12 @@ impl DebugAdapter for PhpDebugAdapter {
         DebugAdapterName(Self::ADAPTER_NAME.into())
     }
 
-    async fn connect(
-        &self,
-        adapter_binary: &DebugAdapterBinary,
-        cx: &mut AsyncAppContext,
-    ) -> Result<TransportParams> {
-        let host = TCPHost {
+    fn transport(&self) -> Box<dyn Transport> {
+        Box::new(TcpTransport::new(TCPHost {
             port: Some(8132),
             host: None,
             delay: Some(1000),
-        };
-
-        create_tcp_client(host, adapter_binary, cx).await
+        }))
     }
 
     async fn fetch_binary(

--- a/crates/dap_adapters/src/python.rs
+++ b/crates/dap_adapters/src/python.rs
@@ -1,3 +1,5 @@
+use dap::transport::{StdioTransport, Transport};
+
 use crate::*;
 
 #[derive(Debug, Eq, PartialEq, Clone)]
@@ -18,12 +20,8 @@ impl DebugAdapter for PythonDebugAdapter {
         DebugAdapterName(Self::ADAPTER_NAME.into())
     }
 
-    async fn connect(
-        &self,
-        adapter_binary: &DebugAdapterBinary,
-        _: &mut AsyncAppContext,
-    ) -> Result<TransportParams> {
-        create_stdio_client(adapter_binary)
+    fn transport(&self) -> Box<dyn Transport> {
+        Box::new(StdioTransport::new())
     }
 
     async fn fetch_binary(

--- a/crates/task/src/debug_format.rs
+++ b/crates/task/src/debug_format.rs
@@ -19,8 +19,8 @@ pub struct TCPHost {
     pub port: Option<u16>,
     /// The host that the debug adapter is listening too
     pub host: Option<Ipv4Addr>,
-    /// The delay in ms between starting and connecting to the debug adapter
-    pub delay: Option<u64>,
+    /// The max amount of time to connect to a tcp DAP before returning an error
+    pub timeout: Option<u64>,
 }
 
 /// Represents the type that will determine which request to call on the debug adapter


### PR DESCRIPTION
This PR cleans up how we connect to a debug adapter.
Previously, this was done inside the debug adapter implementation.

While reviewing the debugger RPC log view PR,
I noticed that we could simplify the transport/client code,
making it easier to attach handlers for logging RPC messages.

CC @Anthony-Eid 