### PR TITLE
Allow users to configure `host`, `port` and `timeout` for build in TCP adapters

### DIFF
--- a/crates/dap/src/adapters.rs
+++ b/crates/dap/src/adapters.rs
@@ -20,7 +20,7 @@ pub trait DapDelegate {
     fn http_client(&self) -> Option<Arc<dyn HttpClient>>;
     fn node_runtime(&self) -> Option<NodeRuntime>;
     fn fs(&self) -> Arc<dyn Fs>;
-    fn cached_binaries(&self) -> Arc<Mutex<HashMap<DebugAdapterName, DebugAdapterBinary>>>;
+    fn updated_adapters(&self) -> Arc<Mutex<HashSet<DebugAdapterName>>>;
 }
 
 #[derive(PartialEq, Eq, Hash, Debug)]
@@ -183,9 +183,15 @@ pub trait DebugAdapter: 'static + Send + Sync {
         delegate: &dyn DapDelegate,
         config: &DebugAdapterConfig,
     ) -> Result<DebugAdapterBinary> {
-        if let Some(binary) = delegate.cached_binaries().lock().await.get(&self.name()) {
+        if delegate
+            .updated_adapters()
+            .lock()
+            .await
+            .contains(&self.name())
+        {
             log::info!("Using cached debug adapter binary {}", self.name());
-            return Ok(binary.clone());
+
+            return self.get_installed_binary(delegate, config).await;
         }
 
         log::info!("Getting latest version of debug adapter {}", self.name());
@@ -198,28 +204,31 @@ pub trait DebugAdapter: 'static + Send + Sync {
                 .as_ref()
                 .is_ok_and(|binary| binary.version == version.tag_name)
             {
-                let binary = binary?;
-
                 delegate
-                    .cached_binaries()
+                    .updated_adapters()
                     .lock_arc()
                     .await
-                    .insert(self.name(), binary.clone());
+                    .insert(self.name());
 
-                return Ok(binary);
+                return Ok(binary?);
             }
 
             self.install_binary(version, delegate).await?;
             binary = self.get_installed_binary(delegate, config).await;
+        } else {
+            log::error!(
+                "Failed getting latest version of debug adapter {}",
+                self.name()
+            );
         }
 
         let binary = binary?;
 
         delegate
-            .cached_binaries()
+            .updated_adapters()
             .lock_arc()
             .await
-            .insert(self.name(), binary.clone());
+            .insert(self.name());
 
         Ok(binary)
     }

--- a/crates/dap/src/debugger_settings.rs
+++ b/crates/dap/src/debugger_settings.rs
@@ -19,6 +19,10 @@ pub struct DebuggerSettings {
     ///
     /// Default: true
     pub button: bool,
+    /// Time in milliseconds until timeout error when connecting to a TCP debug adapter
+    ///
+    /// Default: 2000ms
+    pub timeout: u64,
 }
 
 impl Default for DebuggerSettings {
@@ -27,6 +31,7 @@ impl Default for DebuggerSettings {
             button: true,
             save_breakpoints: true,
             stepping_granularity: SteppingGranularity::Line,
+            timeout: 2000,
         }
     }
 }

--- a/crates/dap/src/transport.rs
+++ b/crates/dap/src/transport.rs
@@ -361,27 +361,38 @@ pub trait Transport: 'static + Send + Sync {
     ) -> Result<TransportParams>;
 
     fn has_adapter_logs(&self) -> bool;
+
+    fn clone_box(&self) -> Box<dyn Transport>;
 }
 
+#[derive(Clone)]
 pub struct TcpTransport {
-    config: TCPHost,
+    port: u16,
+    host: Ipv4Addr,
+    timeout: Option<u64>,
 }
 
 impl TcpTransport {
-    pub fn new(config: TCPHost) -> Self {
-        Self { config }
+    const DEFAULT_TIMEOUT: u64 = 2000;
+
+    pub fn new(host: Ipv4Addr, port: u16, timeout: Option<u64>) -> Self {
+        Self {
+            port,
+            host,
+            timeout,
+        }
     }
 
     /// Get an open port to use with the tcp client when not supplied by debug config
-    async fn get_open_port(host: Ipv4Addr) -> Option<u16> {
-        Some(
-            TcpListener::bind(SocketAddrV4::new(host, 0))
-                .await
-                .ok()?
-                .local_addr()
-                .ok()?
-                .port(),
-        )
+    pub async fn port(host: &TCPHost) -> Result<u16> {
+        if let Some(port) = host.port {
+            Ok(port)
+        } else {
+            Ok(TcpListener::bind(SocketAddrV4::new(host.host(), 0))
+                .await?
+                .local_addr()?
+                .port())
+        }
     }
 }
 
@@ -392,16 +403,6 @@ impl Transport for TcpTransport {
         binary: &DebugAdapterBinary,
         cx: &mut AsyncAppContext,
     ) -> Result<TransportParams> {
-        let host_address = self
-            .config
-            .host
-            .unwrap_or_else(|| Ipv4Addr::new(127, 0, 0, 1));
-
-        let mut port = self.config.port;
-        if port.is_none() {
-            port = Self::get_open_port(host_address).await;
-        }
-
         let mut command = process::Command::new(&binary.command);
 
         if let Some(args) = &binary.arguments {
@@ -422,16 +423,13 @@ impl Transport for TcpTransport {
             .spawn()
             .with_context(|| "failed to start debug adapter.")?;
 
-        let address = SocketAddrV4::new(
-            host_address,
-            port.ok_or(anyhow!("Port is required to connect to TCP server"))?,
-        );
+        let address = SocketAddrV4::new(self.host, self.port);
 
-        let timeout = self.config.timeout.unwrap_or(2000);
+        let timeout = self.timeout.unwrap_or(Self::DEFAULT_TIMEOUT);
 
         let (rx, tx) = select! {
             _ = cx.background_executor().timer(Duration::from_millis(timeout)).fuse() => {
-                return Err(anyhow!("Connection to tcp DAP timeout"))
+                return Err(anyhow!(format!("Connection to TCP DAP timeout {}:{}", self.host, self.port)))
             },
             result = cx.spawn(|cx| async move {
                 loop {
@@ -444,7 +442,11 @@ impl Transport for TcpTransport {
                 }
             }).fuse() => result
         };
-        log::info!("Debug adapter has connected to tcp server");
+        log::info!(
+            "Debug adapter has connected to TCP server {}:{}",
+            self.host,
+            self.port
+        );
 
         Ok(TransportParams::new(
             Box::new(tx),
@@ -456,8 +458,13 @@ impl Transport for TcpTransport {
     fn has_adapter_logs(&self) -> bool {
         true
     }
+
+    fn clone_box(&self) -> Box<dyn Transport> {
+        Box::new(self.clone())
+    }
 }
 
+#[derive(Clone)]
 pub struct StdioTransport {}
 
 impl StdioTransport {
@@ -513,5 +520,9 @@ impl Transport for StdioTransport {
 
     fn has_adapter_logs(&self) -> bool {
         false
+    }
+
+    fn clone_box(&self) -> Box<dyn Transport> {
+        Box::new(self.clone())
     }
 }

--- a/crates/dap_adapters/Cargo.toml
+++ b/crates/dap_adapters/Cargo.toml
@@ -5,7 +5,6 @@ edition =  "2021"
 publish =  false
 license = "GPL-3.0-or-later"
 
-
 [lints]
 workspace = true
 

--- a/crates/dap_adapters/src/dap_adapters.rs
+++ b/crates/dap_adapters/src/dap_adapters.rs
@@ -16,17 +16,18 @@ use lldb::LldbDebugAdapter;
 use php::PhpDebugAdapter;
 use python::PythonDebugAdapter;
 use serde_json::{json, Value};
-use std::fmt::Debug;
 use task::{CustomArgs, DebugAdapterConfig, DebugAdapterKind, DebugConnectionType, TCPHost};
 
-pub fn build_adapter(adapter_config: &DebugAdapterConfig) -> Result<Box<dyn DebugAdapter>> {
+pub async fn build_adapter(adapter_config: &DebugAdapterConfig) -> Result<Box<dyn DebugAdapter>> {
     match &adapter_config.kind {
         DebugAdapterKind::Custom(start_args) => {
-            Ok(Box::new(CustomDebugAdapter::new(start_args.clone())))
+            Ok(Box::new(CustomDebugAdapter::new(start_args.clone()).await?))
         }
         DebugAdapterKind::Python => Ok(Box::new(PythonDebugAdapter::new())),
-        DebugAdapterKind::PHP => Ok(Box::new(PhpDebugAdapter::new())),
-        DebugAdapterKind::Javascript => Ok(Box::new(JsDebugAdapter::new())),
+        DebugAdapterKind::PHP(host) => Ok(Box::new(PhpDebugAdapter::new(host.clone()).await?)),
+        DebugAdapterKind::Javascript(host) => {
+            Ok(Box::new(JsDebugAdapter::new(host.clone()).await?))
+        }
         DebugAdapterKind::Lldb => Ok(Box::new(LldbDebugAdapter::new())),
     }
 }

--- a/crates/dap_adapters/src/lldb.rs
+++ b/crates/dap_adapters/src/lldb.rs
@@ -5,7 +5,6 @@ use task::DebugAdapterConfig;
 
 use crate::*;
 
-#[derive(Debug, Eq, PartialEq, Clone)]
 pub(crate) struct LldbDebugAdapter {}
 
 impl LldbDebugAdapter {

--- a/crates/dap_adapters/src/python.rs
+++ b/crates/dap_adapters/src/python.rs
@@ -2,7 +2,6 @@ use dap::transport::{StdioTransport, Transport};
 
 use crate::*;
 
-#[derive(Debug, Eq, PartialEq, Clone)]
 pub(crate) struct PythonDebugAdapter {}
 
 impl PythonDebugAdapter {

--- a/crates/debugger_tools/src/dap_log.rs
+++ b/crates/debugger_tools/src/dap_log.rs
@@ -520,7 +520,7 @@ impl DapLogView {
             .debug_clients(cx)
             .map(|client| DapMenuItem {
                 client_id: client.id(),
-                client_name: client.config().kind.to_string(),
+                client_name: client.config().kind.diplay_name().into(),
                 selected_entry: self.current_view.map_or(LogKind::Adapter, |(_, kind)| kind),
                 has_adapter_logs: client.has_adapter_logs(),
             })

--- a/crates/debugger_ui/src/debugger_panel_item.rs
+++ b/crates/debugger_ui/src/debugger_panel_item.rs
@@ -496,8 +496,9 @@ impl Item for DebugPanelItem {
         _: &WindowContext,
     ) -> AnyElement {
         Label::new(format!(
-            "{:?} - Thread {}",
-            self.client_kind, self.thread_id
+            "{} - Thread {}",
+            self.client_kind.diplay_name(),
+            self.thread_id
         ))
         .color(if params.selected {
             Color::Default
@@ -509,8 +510,8 @@ impl Item for DebugPanelItem {
 
     fn tab_tooltip_text(&self, cx: &AppContext) -> Option<SharedString> {
         Some(SharedString::from(format!(
-            "{:?} Thread {} - {:?}",
-            self.client_kind,
+            "{} Thread {} - {:?}",
+            self.client_kind.diplay_name(),
             self.thread_id,
             self.thread_state.read(cx).status,
         )))

--- a/crates/project/src/dap_store.rs
+++ b/crates/project/src/dap_store.rs
@@ -253,6 +253,7 @@ impl DapStore {
             let dap_store = this.clone();
             let adapter = Arc::new(
                 build_adapter(&config)
+                    .await
                     .context("Creating debug adapter")
                     .log_err()?,
             );

--- a/crates/project/src/dap_store.rs
+++ b/crates/project/src/dap_store.rs
@@ -1,7 +1,6 @@
 use crate::ProjectPath;
 use anyhow::{anyhow, Context as _, Result};
-use collections::HashSet;
-use dap::adapters::{DebugAdapterBinary, DebugAdapterName};
+use dap::adapters::DebugAdapterName;
 use dap::client::{DebugAdapterClient, DebugAdapterClientId};
 use dap::messages::{Message, Response};
 use dap::requests::{
@@ -31,7 +30,7 @@ use serde_json::{json, Value};
 use settings::WorktreeId;
 use smol::lock::Mutex;
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, HashMap, HashSet},
     hash::{Hash, Hasher},
     path::{Path, PathBuf},
     sync::{
@@ -67,7 +66,7 @@ pub struct DebugPosition {
 pub struct DapStore {
     next_client_id: AtomicUsize,
     clients: HashMap<DebugAdapterClientId, DebugAdapterClientState>,
-    cached_binaries: Arc<Mutex<HashMap<DebugAdapterName, DebugAdapterBinary>>>,
+    updated_adapters: Arc<Mutex<HashSet<DebugAdapterName>>>,
     breakpoints: BTreeMap<ProjectPath, HashSet<Breakpoint>>,
     capabilities: HashMap<DebugAdapterClientId, Capabilities>,
     active_debug_line: Option<(ProjectPath, DebugPosition)>,
@@ -90,7 +89,7 @@ impl DapStore {
         Self {
             active_debug_line: None,
             clients: Default::default(),
-            cached_binaries: Default::default(),
+            updated_adapters: Default::default(),
             breakpoints: Default::default(),
             capabilities: HashMap::default(),
             next_client_id: Default::default(),
@@ -247,7 +246,7 @@ impl DapStore {
             self.http_client.clone(),
             self.node_runtime.clone(),
             self.fs.clone(),
-            self.cached_binaries.clone(),
+            self.updated_adapters.clone(),
         );
         let start_client_task = cx.spawn(|this, mut cx| async move {
             let dap_store = this.clone();
@@ -1234,7 +1233,7 @@ pub struct DapAdapterDelegate {
     fs: Arc<dyn Fs>,
     http_client: Option<Arc<dyn HttpClient>>,
     node_runtime: Option<NodeRuntime>,
-    cached_binaries: Arc<Mutex<HashMap<DebugAdapterName, DebugAdapterBinary>>>,
+    udpated_adapters: Arc<Mutex<HashSet<DebugAdapterName>>>,
 }
 
 impl DapAdapterDelegate {
@@ -1242,13 +1241,13 @@ impl DapAdapterDelegate {
         http_client: Option<Arc<dyn HttpClient>>,
         node_runtime: Option<NodeRuntime>,
         fs: Arc<dyn Fs>,
-        cached_binaries: Arc<Mutex<HashMap<DebugAdapterName, DebugAdapterBinary>>>,
+        udpated_adapters: Arc<Mutex<HashSet<DebugAdapterName>>>,
     ) -> Self {
         Self {
             fs,
             http_client,
             node_runtime,
-            cached_binaries,
+            udpated_adapters,
         }
     }
 }
@@ -1266,7 +1265,7 @@ impl dap::adapters::DapDelegate for DapAdapterDelegate {
         self.fs.clone()
     }
 
-    fn cached_binaries(&self) -> Arc<Mutex<HashMap<DebugAdapterName, DebugAdapterBinary>>> {
-        self.cached_binaries.clone()
+    fn updated_adapters(&self) -> Arc<Mutex<HashSet<DebugAdapterName>>> {
+        self.udpated_adapters.clone()
     }
 }

--- a/crates/task/src/debug_format.rs
+++ b/crates/task/src/debug_format.rs
@@ -44,22 +44,23 @@ pub enum DebugAdapterKind {
     /// Use debugpy
     Python,
     /// Use vscode-php-debug
-    PHP,
+    PHP(TCPHost),
     /// Use vscode-js-debug
-    Javascript,
+    Javascript(TCPHost),
     /// Use lldb
     Lldb,
 }
 
-impl std::fmt::Display for DebugAdapterKind {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(match self {
+impl DebugAdapterKind {
+    /// Returns the display name for the adapter kind
+    pub fn diplay_name(&self) -> &str {
+        match self {
             Self::Custom(_) => "Custom",
             Self::Python => "Python",
-            Self::PHP => "PHP",
-            Self::Javascript => "JavaScript",
+            Self::PHP(_) => "PHP",
+            Self::Javascript(_) => "JavaScript",
             Self::Lldb => "LLDB",
-        })
+        }
     }
 }
 

--- a/crates/task/src/debug_format.rs
+++ b/crates/task/src/debug_format.rs
@@ -16,10 +16,16 @@ impl Default for DebugConnectionType {
 #[derive(Default, Deserialize, Serialize, PartialEq, Eq, JsonSchema, Clone, Debug)]
 pub struct TCPHost {
     /// The port that the debug adapter is listening on
+    ///
+    /// Default: We will try to find an open port
     pub port: Option<u16>,
     /// The host that the debug adapter is listening too
+    ///
+    /// Default: 127.0.0.1
     pub host: Option<Ipv4Addr>,
-    /// The max amount of time to connect to a tcp DAP before returning an error
+    /// The max amount of time in milliseconds to connect to a tcp DAP before returning an error
+    ///
+    /// Default: 2000ms
     pub timeout: Option<u64>,
 }
 

--- a/crates/task/src/debug_format.rs
+++ b/crates/task/src/debug_format.rs
@@ -23,6 +23,13 @@ pub struct TCPHost {
     pub timeout: Option<u64>,
 }
 
+impl TCPHost {
+    /// Get the host or fallback to the default host
+    pub fn host(&self) -> Ipv4Addr {
+        self.host.unwrap_or_else(|| Ipv4Addr::new(127, 0, 0, 1))
+    }
+}
+
 /// Represents the type that will determine which request to call on the debug adapter
 #[derive(Default, Deserialize, Serialize, PartialEq, Eq, JsonSchema, Clone, Debug)]
 #[serde(rename_all = "lowercase")]


### PR DESCRIPTION
This PR enhances user configurability for built-in adapters utilizing TCP transport by allowing customization of `host`, `port`, and `timeout` settings. Additionally, we've implemented a feature where, if no **port** is specified, the system will automatically attempt to locate an **available port** on the provided **host**.

TODO:
- [x] Update or remove the cached binaries functionality, as the host/port information is no longer stored within the DebugAdapterBinary