### PR TITLE
Get users python binary path based on `which` instead of `python3` & pass shell_env to Adapters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3355,6 +3355,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "collections",
  "dap-types",
  "fs",
  "futures 0.3.30",

--- a/crates/dap/Cargo.toml
+++ b/crates/dap/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
+collections.workspace = true
 dap-types = { git = "https://github.com/zed-industries/dap-types", rev = "b95818130022bfc72bbcd639bdd0c0358c7549fc" }
 fs.workspace = true
 futures.workspace = true

--- a/crates/dap/src/adapters.rs
+++ b/crates/dap/src/adapters.rs
@@ -9,7 +9,7 @@ use serde_json::Value;
 use smol::{self, fs::File, lock::Mutex, process};
 use std::{
     collections::{HashMap, HashSet},
-    ffi::OsString,
+    ffi::{OsStr, OsString},
     fmt::Debug,
     ops::Deref,
     path::{Path, PathBuf},
@@ -32,6 +32,7 @@ pub trait DapDelegate {
     fn fs(&self) -> Arc<dyn Fs>;
     fn updated_adapters(&self) -> Arc<Mutex<HashSet<DebugAdapterName>>>;
     fn update_status(&self, dap_name: DebugAdapterName, status: DapStatus);
+    fn which(&self, command: &OsStr) -> Option<PathBuf>;
 }
 
 #[derive(PartialEq, Eq, Hash, Debug)]

--- a/crates/dap/src/adapters.rs
+++ b/crates/dap/src/adapters.rs
@@ -26,6 +26,7 @@ pub enum DapStatus {
     Failed { error: String },
 }
 
+#[async_trait(?Send)]
 pub trait DapDelegate {
     fn http_client(&self) -> Option<Arc<dyn HttpClient>>;
     fn node_runtime(&self) -> Option<NodeRuntime>;
@@ -33,6 +34,7 @@ pub trait DapDelegate {
     fn updated_adapters(&self) -> Arc<Mutex<HashSet<DebugAdapterName>>>;
     fn update_status(&self, dap_name: DebugAdapterName, status: DapStatus);
     fn which(&self, command: &OsStr) -> Option<PathBuf>;
+    async fn shell_env(&self) -> collections::HashMap<String, String>;
 }
 
 #[derive(PartialEq, Eq, Hash, Debug)]

--- a/crates/dap_adapters/src/python.rs
+++ b/crates/dap_adapters/src/python.rs
@@ -87,7 +87,7 @@ impl DebugAdapter for PythonDebugAdapter {
             None => adapter_info?,
         };
 
-        let python_cmds = vec![
+        let python_cmds = [
             OsStr::new("python3"),
             OsStr::new("python"),
             OsStr::new("py"),

--- a/crates/dap_adapters/src/python.rs
+++ b/crates/dap_adapters/src/python.rs
@@ -1,5 +1,5 @@
 use dap::transport::{TcpTransport, Transport};
-use std::{net::Ipv4Addr, path::PathBuf};
+use std::{ffi::OsStr, net::Ipv4Addr, path::PathBuf};
 use util::maybe;
 
 use crate::*;
@@ -56,7 +56,7 @@ impl DebugAdapter for PythonDebugAdapter {
 
     async fn get_installed_binary(
         &self,
-        _: &dyn DapDelegate,
+        delegate: &dyn DapDelegate,
         config: &DebugAdapterConfig,
         user_installed_path: Option<PathBuf>,
     ) -> Result<DebugAdapterBinary> {
@@ -87,8 +87,26 @@ impl DebugAdapter for PythonDebugAdapter {
             None => adapter_info?,
         };
 
+        let python_cmds = vec![
+            OsStr::new("python3"),
+            OsStr::new("python"),
+            OsStr::new("py"),
+        ];
+        let python_path = python_cmds
+            .iter()
+            .filter_map(|cmd| {
+                delegate
+                    .which(cmd)
+                    .and_then(|path| path.to_str().map(|str| str.to_string()))
+            })
+            .find(|_| true);
+
+        let python_path = python_path.ok_or(anyhow!(
+            "Failed to start debugger because python couldn't be found in PATH"
+        ))?;
+
         Ok(DebugAdapterBinary {
-            command: "python3".to_string(),
+            command: python_path,
             arguments: Some(vec![
                 debugpy_dir.join(Self::ADAPTER_PATH).into(),
                 format!("--port={}", self.port).into(),

--- a/crates/project/src/dap_store.rs
+++ b/crates/project/src/dap_store.rs
@@ -1,5 +1,7 @@
 use crate::{project_settings::ProjectSettings, ProjectEnvironment, ProjectPath};
 use anyhow::{anyhow, Context as _, Result};
+use async_trait::async_trait;
+use collections::HashMap;
 use dap::adapters::{DapDelegate, DapStatus, DebugAdapterName};
 use dap::{
     client::{DebugAdapterClient, DebugAdapterClientId},
@@ -22,6 +24,8 @@ use dap::{
 };
 use dap_adapters::build_adapter;
 use fs::Fs;
+use futures::future::Shared;
+use futures::FutureExt;
 use gpui::{EventEmitter, Model, ModelContext, SharedString, Task};
 use http_client::HttpClient;
 use language::{
@@ -32,7 +36,7 @@ use serde_json::Value;
 use settings::{Settings, WorktreeId};
 use smol::lock::Mutex;
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, HashSet},
     ffi::OsStr,
     hash::{Hash, Hasher},
     path::{Path, PathBuf},
@@ -68,11 +72,11 @@ pub struct DebugPosition {
 
 pub struct DapStore {
     next_client_id: AtomicUsize,
-    delegate: Arc<DapAdapterDelegate>,
+    delegate: DapAdapterDelegate,
     breakpoints: BTreeMap<ProjectPath, HashSet<Breakpoint>>,
     active_debug_line: Option<(ProjectPath, DebugPosition)>,
     capabilities: HashMap<DebugAdapterClientId, Capabilities>,
-    _environment: Model<ProjectEnvironment>,
+    environment: Model<ProjectEnvironment>,
     clients: HashMap<DebugAdapterClientId, DebugAdapterClientState>,
 }
 
@@ -89,21 +93,39 @@ impl DapStore {
     ) -> Self {
         cx.on_app_quit(Self::shutdown_clients).detach();
 
+        let load_shell_env_task = Task::ready(None).shared();
+
         Self {
             active_debug_line: None,
             clients: Default::default(),
             breakpoints: Default::default(),
             capabilities: HashMap::default(),
             next_client_id: Default::default(),
-            delegate: Arc::new(DapAdapterDelegate::new(
+            delegate: DapAdapterDelegate::new(
                 http_client.clone(),
                 node_runtime.clone(),
                 fs.clone(),
                 languages.clone(),
-                environment.clone(),
-            )),
-            _environment: environment,
+                load_shell_env_task,
+            ),
+            environment,
         }
+    }
+
+    pub fn delegate(
+        &self,
+        cwd: &Option<PathBuf>,
+        cx: &mut ModelContext<Self>,
+    ) -> Arc<DapAdapterDelegate> {
+        let worktree_abs_path = cwd.as_ref().map(|p| Arc::from(p.as_path()));
+        let task = self.environment.update(cx, |env, cx| {
+            env.get_environment(None, worktree_abs_path, cx)
+        });
+
+        let mut delegate = self.delegate.clone();
+        delegate.refresh_shell_env_task(task);
+
+        Arc::new(delegate)
     }
 
     pub fn next_client_id(&self) -> DebugAdapterClientId {
@@ -244,7 +266,7 @@ impl DapStore {
 
     pub fn start_client(&mut self, config: DebugAdapterConfig, cx: &mut ModelContext<Self>) {
         let client_id = self.next_client_id();
-        let adapter_delegate = self.delegate.clone();
+        let adapter_delegate = self.delegate(&config.cwd, cx);
 
         let start_client_task = cx.spawn(|this, mut cx| async move {
             let dap_store = this.clone();
@@ -284,8 +306,13 @@ impl DapStore {
 
                         return Err(error);
                     }
-                    Ok(binary) => {
+                    Ok(mut binary) => {
                         adapter_delegate.update_status(adapter.name(), DapStatus::None);
+
+                        let shell_env = adapter_delegate.shell_env().await;
+                        let mut envs = binary.envs.unwrap_or_default();
+                        envs.extend(shell_env);
+                        binary.envs = Some(envs);
 
                         binary
                     }
@@ -1309,7 +1336,7 @@ pub struct DapAdapterDelegate {
     node_runtime: Option<NodeRuntime>,
     updated_adapters: Arc<Mutex<HashSet<DebugAdapterName>>>,
     languages: Arc<LanguageRegistry>,
-    _environment: Model<ProjectEnvironment>,
+    load_shell_env_task: Shared<Task<Option<HashMap<String, String>>>>,
 }
 
 impl DapAdapterDelegate {
@@ -1318,19 +1345,27 @@ impl DapAdapterDelegate {
         node_runtime: Option<NodeRuntime>,
         fs: Arc<dyn Fs>,
         languages: Arc<LanguageRegistry>,
-        environment: Model<ProjectEnvironment>,
+        load_shell_env_task: Shared<Task<Option<HashMap<String, String>>>>,
     ) -> Self {
         Self {
             fs,
             languages,
             http_client,
             node_runtime,
+            load_shell_env_task,
             updated_adapters: Default::default(),
-            _environment: environment,
         }
+    }
+
+    pub(crate) fn refresh_shell_env_task(
+        &mut self,
+        load_shell_env_task: Shared<Task<Option<HashMap<String, String>>>>,
+    ) {
+        self.load_shell_env_task = load_shell_env_task;
     }
 }
 
+#[async_trait(?Send)]
 impl dap::adapters::DapDelegate for DapAdapterDelegate {
     fn http_client(&self) -> Option<Arc<dyn HttpClient>> {
         self.http_client.clone()
@@ -1363,5 +1398,10 @@ impl dap::adapters::DapDelegate for DapAdapterDelegate {
 
     fn which(&self, command: &OsStr) -> Option<PathBuf> {
         which::which(command).ok()
+    }
+
+    async fn shell_env(&self) -> HashMap<String, String> {
+        let task = self.load_shell_env_task.clone();
+        task.await.unwrap_or_default()
     }
 }

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -625,12 +625,15 @@ impl Project {
             cx.subscribe(&worktree_store, Self::on_worktree_store_event)
                 .detach();
 
+            let environment = ProjectEnvironment::new(&worktree_store, env, cx);
+
             let dap_store = cx.new_model(|cx| {
                 DapStore::new(
                     Some(client.http_client()),
                     Some(node.clone()),
                     fs.clone(),
                     languages.clone(),
+                    environment.clone(),
                     cx,
                 )
             });
@@ -650,8 +653,6 @@ impl Project {
                     cx,
                 )
             });
-
-            let environment = ProjectEnvironment::new(&worktree_store, env, cx);
 
             let task_store = cx.new_model(|cx| {
                 TaskStore::local(
@@ -804,6 +805,7 @@ impl Project {
                     Some(node.clone()),
                     fs.clone(),
                     languages.clone(),
+                    environment.clone(),
                     cx,
                 )
             });
@@ -964,12 +966,15 @@ impl Project {
             BufferStore::remote(worktree_store.clone(), client.clone().into(), remote_id, cx)
         })?;
 
+        let environment = cx.update(|cx| ProjectEnvironment::new(&worktree_store, None, cx))?;
+
         let dap_store = cx.new_model(|cx| {
             DapStore::new(
                 Some(client.http_client()),
                 None,
                 fs.clone(),
                 languages.clone(),
+                environment.clone(),
                 cx,
             )
         })?;
@@ -1068,7 +1073,7 @@ impl Project {
                 search_history: Self::new_search_history(),
                 search_included_history: Self::new_search_history(),
                 search_excluded_history: Self::new_search_history(),
-                environment: ProjectEnvironment::new(&worktree_store, None, cx),
+                environment,
                 remotely_created_models: Arc::new(Mutex::new(RemotelyCreatedModels::default())),
                 toolchain_store: None,
             };

--- a/crates/remote_server/src/headless_project.rs
+++ b/crates/remote_server/src/headless_project.rs
@@ -73,8 +73,18 @@ impl HeadlessProject {
             store
         });
 
-        let dap_store =
-            cx.new_model(|cx| DapStore::new(None, None, fs.clone(), languages.clone(), cx));
+        let environment = project::ProjectEnvironment::new(&worktree_store, None, cx);
+
+        let dap_store = cx.new_model(|cx| {
+            DapStore::new(
+                None,
+                None,
+                fs.clone(),
+                languages.clone(),
+                environment.clone(),
+                cx,
+            )
+        });
         let buffer_store = cx.new_model(|cx| {
             let mut buffer_store =
                 BufferStore::local(worktree_store.clone(), dap_store.clone(), cx);
@@ -91,7 +101,6 @@ impl HeadlessProject {
             )
         });
 
-        let environment = project::ProjectEnvironment::new(&worktree_store, None, cx);
         let task_store = cx.new_model(|cx| {
             let mut task_store = TaskStore::local(
                 fs.clone(),


### PR DESCRIPTION
This fixes the assumption that the python debug adapter made where it assumes the user has Python installed as python3 within their path. 

This also passes the shell_env of the users cwd from their debug config, which is the first step of allowing users to pass in environmental variables from debug.json