### PR TITLE
Go Adapter Implementation

### DIFF
--- a/crates/dap_adapters/src/dap_adapters.rs
+++ b/crates/dap_adapters/src/dap_adapters.rs
@@ -12,6 +12,7 @@ use dap::adapters::{
     self, AdapterVersion, DapDelegate, DebugAdapter, DebugAdapterBinary, DebugAdapterName,
     GithubRepo,
 };
+use go::GoDebugAdapter;
 use javascript::JsDebugAdapter;
 use lldb::LldbDebugAdapter;
 use php::PhpDebugAdapter;
@@ -31,5 +32,6 @@ pub async fn build_adapter(kind: &DebugAdapterKind) -> Result<Box<dyn DebugAdapt
             Ok(Box::new(JsDebugAdapter::new(host.clone()).await?))
         }
         DebugAdapterKind::Lldb => Ok(Box::new(LldbDebugAdapter::new())),
+        DebugAdapterKind::Go(host) => Ok(Box::new(GoDebugAdapter::new(host).await?)),
     }
 }

--- a/crates/dap_adapters/src/dap_adapters.rs
+++ b/crates/dap_adapters/src/dap_adapters.rs
@@ -1,4 +1,5 @@
 mod custom;
+mod go;
 mod javascript;
 mod lldb;
 mod php;

--- a/crates/dap_adapters/src/go.rs
+++ b/crates/dap_adapters/src/go.rs
@@ -1,0 +1,106 @@
+use dap::transport::{TcpTransport, Transport};
+use std::{net::Ipv4Addr, path::PathBuf};
+use util::maybe;
+
+use crate::*;
+
+pub(crate) struct GoDebugAdapter {
+    port: u16,
+    host: Ipv4Addr,
+    timeout: Option<u64>,
+}
+
+impl GoDebugAdapter {
+    const ADAPTER_NAME: &'static str = "delve";
+    // const ADAPTER_PATH: &'static str = "src/debugpy/adapter";
+
+    pub(crate) async fn new(host: &TCPHost) -> Result<Self> {
+        Ok(GoDebugAdapter {
+            port: TcpTransport::port(host).await?,
+            host: host.host(),
+            timeout: host.timeout,
+        })
+    }
+}
+
+#[async_trait(?Send)]
+impl DebugAdapter for GoDebugAdapter {
+    fn name(&self) -> DebugAdapterName {
+        DebugAdapterName(Self::ADAPTER_NAME.into())
+    }
+
+    fn transport(&self) -> Box<dyn Transport> {
+        Box::new(TcpTransport::new(self.host, self.port, self.timeout))
+    }
+
+    async fn fetch_latest_adapter_version(
+        &self,
+        delegate: &dyn DapDelegate,
+    ) -> Result<AdapterVersion> {
+        let github_repo = GithubRepo {
+            repo_name: Self::ADAPTER_NAME.into(),
+            repo_owner: "go-delve".into(),
+        };
+
+        adapters::fetch_latest_adapter_version_from_github(github_repo, delegate).await
+    }
+
+    async fn install_binary(
+        &self,
+        version: AdapterVersion,
+        delegate: &dyn DapDelegate,
+    ) -> Result<()> {
+        adapters::download_adapter_from_github(self.name(), version, delegate).await?;
+        Ok(())
+    }
+
+    async fn get_installed_binary(
+        &self,
+        _: &dyn DapDelegate,
+        config: &DebugAdapterConfig,
+        user_installed_path: Option<PathBuf>,
+    ) -> Result<DebugAdapterBinary> {
+        let adapter_path = paths::debug_adapters_dir().join(self.name());
+        let file_name_prefix = format!("{}_", self.name());
+
+        let adapter_info: Result<_> = maybe!(async {
+            let debugpy_dir =
+                util::fs::find_file_name_in_dir(adapter_path.as_path(), |file_name| {
+                    file_name.starts_with(&file_name_prefix)
+                })
+                .await
+                .ok_or_else(|| anyhow!("Debugpy directory not found"))?;
+
+            let version = debugpy_dir
+                .file_name()
+                .and_then(|file_name| file_name.to_str())
+                .and_then(|file_name| file_name.strip_prefix(&file_name_prefix))
+                .ok_or_else(|| anyhow!("Python debug adapter has invalid file name"))?
+                .to_string();
+
+            Ok((debugpy_dir, version))
+        })
+        .await;
+
+        let (debugpy_dir, version) = match user_installed_path {
+            Some(path) => (path, "N/A".into()),
+            None => adapter_info?,
+        };
+
+        Ok(DebugAdapterBinary {
+            command: "python3".to_string(),
+            arguments: Some(vec![
+                debugpy_dir.join(Self::ADAPTER_PATH).into(),
+                format!("--port={}", self.port).into(),
+                format!("--host={}", self.host).into(),
+            ]),
+            cwd: config.cwd.clone(),
+            envs: None,
+            version,
+        })
+    }
+
+    fn request_args(&self, config: &DebugAdapterConfig) -> Value {
+        json!({"program": config.program, "subProcess": true})
+    }
+}

--- a/crates/dap_adapters/src/go.rs
+++ b/crates/dap_adapters/src/go.rs
@@ -75,12 +75,12 @@ impl DebugAdapter for GoDebugAdapter {
             .and_then(|p| p.to_str().map(|p| p.to_string()))
             .ok_or(anyhow!("Dlv not found in path"))?;
 
-        let client_address = format!("--client-addr {}:{}", self.host, self.port);
+        let ip_address = format!("{}:{}", self.host, self.port);
         let version = "N/A".into();
 
         Ok(DebugAdapterBinary {
             command: delve_path,
-            arguments: Some(vec!["dap".into(), client_address.into()]),
+            arguments: Some(vec!["dap".into(), "--listen".into(), ip_address.into()]),
             cwd: config.cwd.clone(),
             envs: None,
             version,

--- a/crates/project/src/dap_store.rs
+++ b/crates/project/src/dap_store.rs
@@ -396,8 +396,8 @@ impl DapStore {
                     supports_memory_references: Some(true),
                     supports_progress_reporting: Some(false),
                     supports_invalidated_event: Some(false),
-                    lines_start_at1: Some(false),
-                    columns_start_at1: Some(false),
+                    lines_start_at1: Some(true),
+                    columns_start_at1: Some(true),
                     supports_memory_event: Some(false),
                     supports_args_can_be_interpreted_by_shell: Some(false),
                     supports_start_debugging_request: Some(true),
@@ -1232,14 +1232,19 @@ impl Breakpoint {
     pub fn to_source_breakpoint(&self, buffer: &Buffer) -> SourceBreakpoint {
         let line = self
             .active_position
-            .map(|position| buffer.summary_for_anchor::<Point>(&position).row)
-            .unwrap_or(self.cache_position) as u64;
+            .map(|position| buffer.summary_for_anchor::<Point>(&position).row + 1)
+            .unwrap_or(self.cache_position + 1) as u64;
+
+        let log_message = match &self.kind {
+            BreakpointKind::Standard => None,
+            BreakpointKind::Log(message) => Some(message.clone().to_string()),
+        };
 
         SourceBreakpoint {
             line,
             condition: None,
             hit_condition: None,
-            log_message: None,
+            log_message,
             column: None,
             mode: None,
         }
@@ -1319,7 +1324,7 @@ impl SerializedBreakpoint {
         };
 
         SourceBreakpoint {
-            line: self.position as u64,
+            line: self.position as u64 + 1u64,
             condition: None,
             hit_condition: None,
             log_message,

--- a/crates/task/src/debug_format.rs
+++ b/crates/task/src/debug_format.rs
@@ -69,6 +69,8 @@ pub enum DebugAdapterKind {
     Php(TCPHost),
     /// Use vscode-js-debug
     Javascript(TCPHost),
+    /// Use delve
+    Go(TCPHost),
     /// Use lldb
     Lldb,
 }
@@ -82,6 +84,7 @@ impl DebugAdapterKind {
             Self::Php(_) => "PHP",
             Self::Javascript(_) => "JavaScript",
             Self::Lldb => "LLDB",
+            Self::Go(_) => "Go",
         }
     }
 }


### PR DESCRIPTION
Get Beta version of go adapter working (Last Internal Zed DAP!!) 

This adapter only works if a user has Go & delve in their PATH. It doesn't automatically download & updates itself because the official download process from the Delve docs would add delve to a user's PATH. I want to discuss with the Zed dev team & Remco if that is behavior we're ok with because typical downloads don't affect a user's PATH.

This PR also fixes a bug where some breakpoint line numbers were incorrect when sending to active DAP servers. 