### PR TITLE
Transfer breakpoints on project_panel file rename

### DIFF
--- a/crates/project/src/dap_store.rs
+++ b/crates/project/src/dap_store.rs
@@ -190,6 +190,12 @@ impl DapStore {
         self.active_debug_line.take();
     }
 
+    pub fn on_file_rename(&mut self, old_project_path: ProjectPath, new_project_path: ProjectPath) {
+        if let Some(breakpoints) = self.breakpoints.remove(&old_project_path) {
+            self.breakpoints.insert(new_project_path, breakpoints);
+        }
+    }
+
     pub fn breakpoints(&self) -> &BTreeMap<ProjectPath, HashSet<Breakpoint>> {
         &self.breakpoints
     }

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -871,6 +871,22 @@ impl ProjectPanel {
                 }
                 Ok(CreatedEntry::Included(new_entry)) => {
                     project_panel.update(&mut cx, |project_panel, cx| {
+                        project_panel.project.update(cx, |project, cx| {
+                            let old_path = ProjectPath {
+                                worktree_id,
+                                path: entry.path,
+                            };
+
+                            let new_path = ProjectPath {
+                                worktree_id,
+                                path: new_entry.path.clone()
+                            };
+
+                            project.dap_store().update(cx, |dap_store, _| {
+                                dap_store.on_file_rename(old_path, new_path);
+                            });
+                        });
+
                         if let Some(selection) = &mut project_panel.selection {
                             if selection.entry_id == edited_entry_id {
                                 selection.worktree_id = worktree_id;


### PR DESCRIPTION
Fixes bug where breakpoints failed to transfer when a user uses project_panel::rename to change that file's name