### PR TITLE
Continue with successful variable requests

### DIFF
--- a/crates/debugger_ui/src/variable_list.rs
+++ b/crates/debugger_ui/src/variable_list.rs
@@ -5,7 +5,6 @@ use editor::{
     actions::{self, SelectAll},
     Editor, EditorEvent,
 };
-use futures::future::try_join_all;
 use gpui::{
     anchored, deferred, list, AnyElement, ClipboardItem, DismissEvent, FocusHandle, FocusableView,
     ListState, Model, MouseDownEvent, Point, Subscription, Task, View,
@@ -452,13 +451,7 @@ impl VariableList {
             }
 
             let tasks_results = futures::future::join_all(tasks).await;
-            let result = tasks_results
-                .into_iter()
-                .filter_map(|r| match r {
-                    Ok(res) => Some(res),
-                    Err(_) => None,
-                })
-                .collect::<Vec<_>>();
+            let result = tasks_results.into_iter().filter_map(|result| result.ok());
 
             this.update(&mut cx, |this, cx| {
                 let mut new_variables = BTreeMap::new();

--- a/crates/debugger_ui/src/variable_list.rs
+++ b/crates/debugger_ui/src/variable_list.rs
@@ -451,7 +451,14 @@ impl VariableList {
                 );
             }
 
-            let result = try_join_all(tasks).await?;
+            let tasks_results = futures::future::join_all(tasks).await;
+            let result = tasks_results
+                .into_iter()
+                .filter_map(|r| match r {
+                    Ok(res) => Some(res),
+                    Err(_) => None,
+                })
+                .collect::<Vec<_>>();
 
             this.update(&mut cx, |this, cx| {
                 let mut new_variables = BTreeMap::new();


### PR DESCRIPTION
Not all taks necessarily succeed, for example fetching variables for an async stack will throw errors in the JavaScript debugger. This means that currently all the tasks will be dropped because of the `try_join_all` usages, causing variables from successful requests not to show up.

Before:
<img width="1115" alt="Screenshot 2024-12-15 at 18 58 57" src="https://github.com/user-attachments/assets/39e6ded0-ae7c-4ab0-be01-03acbca5d68d" />

After:
<img width="1110" alt="Screenshot 2024-12-16 at 23 22 44" src="https://github.com/user-attachments/assets/aaa9a620-24d2-4828-b887-60d892db3023" />
