### PR TITLE
Filter attach processes by port

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3612,6 +3612,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "dap",
+ "listeners",
  "paths",
  "regex",
  "serde",
@@ -7206,6 +7207,18 @@ name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "listeners"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "777b1ed64c65e967d6afe3950f5694b60962672156bb53027e25f72a05fcaeb5"
+dependencies = [
+ "byteorder",
+ "once_cell",
+ "rustix 0.38.40",
+ "windows 0.58.0",
+]
 
 [[package]]
 name = "litemap"

--- a/crates/dap/src/adapters.rs
+++ b/crates/dap/src/adapters.rs
@@ -297,7 +297,8 @@ pub trait DebugAdapter: 'static + Send + Sync {
     /// Filters out the processes that the adapter can attach to for debugging
     fn attach_processes<'a>(
         &self,
-        _: &'a HashMap<Pid, Process>,
+        _processes: &'a HashMap<Pid, Process>,
+        _port: Option<u16>,
     ) -> Option<Vec<(&'a Pid, &'a Process)>> {
         None
     }

--- a/crates/dap_adapters/Cargo.toml
+++ b/crates/dap_adapters/Cargo.toml
@@ -23,6 +23,7 @@ doctest = false
 anyhow.workspace = true
 async-trait.workspace = true
 dap.workspace = true
+listeners = "0.2"
 paths.workspace = true
 regex.workspace = true
 serde.workspace = true

--- a/crates/dap_adapters/src/javascript.rs
+++ b/crates/dap_adapters/src/javascript.rs
@@ -147,8 +147,20 @@ impl DebugAdapter for JsDebugAdapter {
     fn attach_processes<'a>(
         &self,
         processes: &'a HashMap<Pid, Process>,
+        port: Option<u16>,
     ) -> Option<Vec<(&'a Pid, &'a Process)>> {
         let regex = Regex::new(r"(?i)^(?:node|bun|iojs)(?:$|\b)").unwrap();
+
+        if let Some(port) = port {
+            if let Ok(processes_by_port) = listeners::get_processes_by_port(port) {
+                return Some(
+                    processes
+                        .iter()
+                        .filter(|(pid, _)| processes_by_port.iter().any(|p| p.pid == pid.as_u32()))
+                        .collect::<Vec<_>>(),
+                );
+            }
+        }
 
         Some(
             processes

--- a/crates/debugger_ui/src/attach_modal.rs
+++ b/crates/debugger_ui/src/attach_modal.rs
@@ -122,8 +122,15 @@ impl PickerDelegate for AttachModalDelegate {
                         };
 
                         let system = System::new_all();
-                        let Some(processes) =
-                            client.adapter().attach_processes(&system.processes())
+                        let initialize_args = client.config().initialize_args;
+                        let port = initialize_args
+                            .as_ref()
+                            .and_then(|args| args.get("port"))
+                            .and_then(|p| p.as_u64());
+
+                        let Some(processes) = client
+                            .adapter()
+                            .attach_processes(&system.processes(), port.map(|p| p as u16))
                         else {
                             return Vec::new();
                         };


### PR DESCRIPTION
Currently the possible attach processes are filtered based on a simple regex (`node|bun|iojs`), this has two issues:
* It can be quite hard to find the right process
* You can't attach to a browser process

This PR adds the option to define a port in the debug task config, which is then used to only show processes that are listening on that port. By doing this it is now possible to attach to an existing browser process, but also makes it easier to find other processes if you know the port it's listening on.

Debugger attached to an already existing browser process:
<img width="3008" alt="Screenshot 2024-12-17 at 22 28 14" src="https://github.com/user-attachments/assets/50af7e84-df0e-4d65-9a47-114c579d90cb" />

Debugger attach modal before filter:
<img width="553" alt="Screenshot 2024-12-17 at 22 30 58" src="https://github.com/user-attachments/assets/61bd0966-a8dd-41e4-ba3d-c3bf549e12c3" />

Debugger attach modal after filter:
<img width="554" alt="Screenshot 2024-12-17 at 22 25 34" src="https://github.com/user-attachments/assets/bf21c843-dad7-417d-a7d4-8a8f5f25c5ae" />

Steps to try this change:
1. Checkout my [example project](https://github.com/gaauwe/zed-debugger-nextjs)
2. Make sure you're browser is started with a debugging port open (`--remote-debugging-port=9222`)
4. Start the project (`npm run dev`)
5. Start the debug task (Next.js: attach to browser)
6. Click the button

_Note that I'm only just getting started with Rust. Therefore this is mostly to demonstrate the idea, feel free to change the code. For example I can imagine you don't want to introduce a third party package just for getting the processes based on port, but I couldn't find a great way to do this otherwise with cross-platform in mind._

Possible other improvements
- [ ] Automatically select a proces if there is only 1 listening on the specified port
- [ ] Improve regex so that browser processes show up without specifying a port