### PR TITLE
Add DAP Step back support

### DIFF
--- a/assets/icons/debug_step_back.svg
+++ b/assets/icons/debug_step_back.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-undo-dot"><path d="M21 17a9 9 0 0 0-15-6.7L3 13"/><path d="M3 7v6h6"/><circle cx="12" cy="17" r="1"/></svg>

--- a/crates/debugger_ui/src/debugger_panel_item.rs
+++ b/crates/debugger_ui/src/debugger_panel_item.rs
@@ -588,6 +588,18 @@ impl DebugPanelItem {
         });
     }
 
+    pub fn step_back(&mut self, cx: &mut ViewContext<Self>) {
+        self.update_thread_state_status(ThreadStatus::Running, cx);
+
+        let granularity = DebuggerSettings::get_global(cx).stepping_granularity;
+
+        self.dap_store.update(cx, |store, cx| {
+            store
+                .step_back(&self.client_id, self.thread_id, granularity, cx)
+                .detach_and_log_err(cx);
+        });
+    }
+
     pub fn restart_client(&self, cx: &mut ViewContext<Self>) {
         self.dap_store.update(cx, |store, cx| {
             store
@@ -807,6 +819,17 @@ impl Render for DebugPanelItem {
                                     .disabled(thread_status != ThreadStatus::Stopped)
                                     .tooltip(move |cx| Tooltip::text("Step out", cx)),
                             )
+                            .when(capabilities.supports_step_back.unwrap_or(false), |this| {
+                                this.child(
+                                    IconButton::new("debug-step-back", IconName::DebugStepBack)
+                                        .icon_size(IconSize::Small)
+                                        .on_click(cx.listener(|this, _, cx| {
+                                            this.step_back(cx);
+                                        }))
+                                        .disabled(thread_status != ThreadStatus::Stopped)
+                                        .tooltip(move |cx| Tooltip::text("Step back", cx)),
+                                )
+                            })
                             .child(
                                 IconButton::new("debug-restart", IconName::DebugRestart)
                                     .icon_size(IconSize::Small)

--- a/crates/debugger_ui/src/debugger_panel_item.rs
+++ b/crates/debugger_ui/src/debugger_panel_item.rs
@@ -792,6 +792,17 @@ impl Render for DebugPanelItem {
                                     )
                                 }
                             })
+                            .when(capabilities.supports_step_back.unwrap_or(false), |this| {
+                                this.child(
+                                    IconButton::new("debug-step-back", IconName::DebugStepBack)
+                                        .icon_size(IconSize::Small)
+                                        .on_click(cx.listener(|this, _, cx| {
+                                            this.step_back(cx);
+                                        }))
+                                        .disabled(thread_status != ThreadStatus::Stopped)
+                                        .tooltip(move |cx| Tooltip::text("Step back", cx)),
+                                )
+                            })
                             .child(
                                 IconButton::new("debug-step-over", IconName::DebugStepOver)
                                     .icon_size(IconSize::Small)
@@ -819,17 +830,6 @@ impl Render for DebugPanelItem {
                                     .disabled(thread_status != ThreadStatus::Stopped)
                                     .tooltip(move |cx| Tooltip::text("Step out", cx)),
                             )
-                            .when(capabilities.supports_step_back.unwrap_or(false), |this| {
-                                this.child(
-                                    IconButton::new("debug-step-back", IconName::DebugStepBack)
-                                        .icon_size(IconSize::Small)
-                                        .on_click(cx.listener(|this, _, cx| {
-                                            this.step_back(cx);
-                                        }))
-                                        .disabled(thread_status != ThreadStatus::Stopped)
-                                        .tooltip(move |cx| Tooltip::text("Step back", cx)),
-                                )
-                            })
                             .child(
                                 IconButton::new("debug-restart", IconName::DebugRestart)
                                     .icon_size(IconSize::Small)

--- a/crates/debugger_ui/src/lib.rs
+++ b/crates/debugger_ui/src/lib.rs
@@ -5,8 +5,8 @@ use gpui::AppContext;
 use settings::Settings;
 use ui::ViewContext;
 use workspace::{
-    Continue, Pause, Restart, ShutdownDebugAdapters, Start, StepInto, StepOut, StepOver, Stop,
-    ToggleIgnoreBreakpoints, Workspace,
+    Continue, Pause, Restart, ShutdownDebugAdapters, Start, StepBack, StepInto, StepOut, StepOver,
+    Stop, ToggleIgnoreBreakpoints, Workspace,
 };
 
 mod attach_modal;
@@ -76,6 +76,17 @@ pub fn init(cx: &mut AppContext) {
                         };
 
                         active_item.update(cx, |item, cx| item.step_in(cx))
+                    });
+                })
+                .register_action(|workspace: &mut Workspace, _: &StepBack, cx| {
+                    let debug_panel = workspace.panel::<DebugPanel>(cx).unwrap();
+
+                    debug_panel.update(cx, |panel, cx| {
+                        let Some(active_item) = panel.active_debug_panel_item(cx) else {
+                            return;
+                        };
+
+                        active_item.update(cx, |item, cx| item.step_back(cx))
                     });
                 })
                 .register_action(|workspace: &mut Workspace, _: &StepOut, cx| {

--- a/crates/project/src/dap_store.rs
+++ b/crates/project/src/dap_store.rs
@@ -1091,6 +1091,13 @@ impl DapStore {
 
         let capabilities = self.capabilities_by_id(client_id);
 
+        if capabilities.supports_step_back.unwrap_or(false) {
+            return Task::ready(Err(anyhow!(
+                "Step back request isn't support for client_id: {:?}",
+                client_id
+            )));
+        }
+
         let supports_single_thread_execution_requests = capabilities
             .supports_single_thread_execution_requests
             .unwrap_or_default();

--- a/crates/project/src/dap_store.rs
+++ b/crates/project/src/dap_store.rs
@@ -3,15 +3,15 @@ use crate::{ProjectEnvironment, ProjectItem as _, ProjectPath};
 use anyhow::{anyhow, Context as _, Result};
 use async_trait::async_trait;
 use collections::HashMap;
-use dap::adapters::{DapDelegate, DapStatus, DebugAdapter, DebugAdapterBinary, DebugAdapterName};
 use dap::{
+    adapters::{DapDelegate, DapStatus, DebugAdapter, DebugAdapterBinary, DebugAdapterName},
     client::{DebugAdapterClient, DebugAdapterClientId},
     messages::{Message, Response},
     requests::{
         Attach, Completions, ConfigurationDone, Continue, Disconnect, Evaluate, Initialize, Launch,
         LoadedSources, Modules, Next, Pause, Request as _, Restart, RunInTerminal, Scopes,
-        SetBreakpoints, SetExpression, SetVariable, StackTrace, StartDebugging, StepIn, StepOut,
-        Terminate, TerminateThreads, Variables,
+        SetBreakpoints, SetExpression, SetVariable, StackTrace, StartDebugging, StepBack, StepIn,
+        StepOut, Terminate, TerminateThreads, Variables,
     },
     AttachRequestArguments, Capabilities, CompletionItem, CompletionsArguments,
     ConfigurationDoneArguments, ContinueArguments, DisconnectArguments, ErrorResponse,
@@ -20,8 +20,9 @@ use dap::{
     ModulesArguments, NextArguments, PauseArguments, RestartArguments, RunInTerminalResponse,
     Scope, ScopesArguments, SetBreakpointsArguments, SetExpressionArguments, SetVariableArguments,
     Source, SourceBreakpoint, StackFrame, StackTraceArguments, StartDebuggingRequestArguments,
-    StartDebuggingRequestArgumentsRequest, StepInArguments, StepOutArguments, SteppingGranularity,
-    TerminateArguments, TerminateThreadsArguments, Variable, VariablesArguments,
+    StartDebuggingRequestArgumentsRequest, StepBackArguments, StepInArguments, StepOutArguments,
+    SteppingGranularity, TerminateArguments, TerminateThreadsArguments, Variable,
+    VariablesArguments,
 };
 use dap_adapters::build_adapter;
 use fs::Fs;
@@ -1069,6 +1070,37 @@ impl DapStore {
         cx.background_executor().spawn(async move {
             client
                 .request::<StepOut>(StepOutArguments {
+                    thread_id,
+                    granularity: supports_stepping_granularity.then(|| granularity),
+                    single_thread: supports_single_thread_execution_requests.then(|| true),
+                })
+                .await
+        })
+    }
+
+    pub fn step_back(
+        &self,
+        client_id: &DebugAdapterClientId,
+        thread_id: u64,
+        granularity: SteppingGranularity,
+        cx: &mut ModelContext<Self>,
+    ) -> Task<Result<()>> {
+        let Some(client) = self.client_by_id(client_id) else {
+            return Task::ready(Err(anyhow!("Could not find client: {:?}", client_id)));
+        };
+
+        let capabilities = self.capabilities_by_id(client_id);
+
+        let supports_single_thread_execution_requests = capabilities
+            .supports_single_thread_execution_requests
+            .unwrap_or_default();
+        let supports_stepping_granularity = capabilities
+            .supports_stepping_granularity
+            .unwrap_or_default();
+
+        cx.background_executor().spawn(async move {
+            client
+                .request::<StepBack>(StepBackArguments {
                     thread_id,
                     granularity: supports_stepping_granularity.then(|| granularity),
                     single_thread: supports_single_thread_execution_requests.then(|| true),

--- a/crates/ui/src/components/icon.rs
+++ b/crates/ui/src/components/icon.rs
@@ -168,6 +168,7 @@ pub enum IconName {
     DebugStepOver,
     DebugStepInto,
     DebugStepOut,
+    DebugStepBack,
     DebugRestart,
     Debug,
     DebugStop,

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -135,6 +135,7 @@ actions!(
         StepInto,
         StepOver,
         StepOut,
+        StepBack,
         Stop,
         ToggleIgnoreBreakpoints
     ]


### PR DESCRIPTION
Release Notes:

- When debugging with a DAP that supports step back Zed will now show a step button button
