### PR TITLE
Collab: Sync DAP Client Capabilities

### DIFF
--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -418,7 +418,10 @@ impl Server {
                 broadcast_project_message_from_host::<proto::RemoveActiveDebugLine>,
             )
             .add_message_handler(broadcast_project_message_from_host::<proto::SetDebuggerPanelItem>)
-            .add_message_handler(broadcast_project_message_from_host::<proto::UpdateDebugAdapter>);
+            .add_message_handler(broadcast_project_message_from_host::<proto::UpdateDebugAdapter>)
+            .add_message_handler(
+                broadcast_project_message_from_host::<proto::SetDebugClientCapabilities>,
+            );
 
         Arc::new(server)
     }

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -421,7 +421,8 @@ impl Server {
             .add_message_handler(broadcast_project_message_from_host::<proto::UpdateDebugAdapter>)
             .add_message_handler(
                 broadcast_project_message_from_host::<proto::SetDebugClientCapabilities>,
-            );
+            )
+            .add_message_handler(broadcast_project_message_from_host::<proto::ShutdownDebugClient>);
 
         Arc::new(server)
     }

--- a/crates/dap/src/proto_conversions.rs
+++ b/crates/dap/src/proto_conversions.rs
@@ -1,9 +1,9 @@
 use anyhow::{anyhow, Result};
 use client::proto::{
     self, DapChecksum, DapChecksumAlgorithm, DapModule, DapScope, DapScopePresentationHint,
-    DapSource, DapSourcePresentationHint, DapStackFrame, DapVariable,
+    DapSource, DapSourcePresentationHint, DapStackFrame, DapVariable, SetDebugClientCapabilities,
 };
-use dap_types::{ScopePresentationHint, Source};
+use dap_types::{Capabilities, ScopePresentationHint, Source};
 
 pub trait ProtoConversion {
     type ProtoType;
@@ -329,5 +329,48 @@ impl ProtoConversion for dap_types::Module {
             date_time_stamp: payload.date_time_stamp,
             address_range: payload.address_range,
         })
+    }
+}
+
+pub fn capabilities_from_proto(payload: &SetDebugClientCapabilities) -> Capabilities {
+    Capabilities {
+        supports_loaded_sources_request: Some(payload.supports_loaded_sources_request),
+        supports_modules_request: Some(payload.supports_modules_request),
+        supports_restart_request: Some(payload.supports_restart_request),
+        supports_set_expression: Some(payload.supports_set_expression),
+        supports_single_thread_execution_requests: Some(
+            payload.supports_single_thread_execution_requests,
+        ),
+        supports_step_back: Some(payload.supports_step_back),
+        supports_stepping_granularity: Some(payload.supports_stepping_granularity),
+        supports_terminate_threads_request: Some(payload.supports_terminate_threads_request),
+        ..Default::default()
+    }
+}
+
+pub fn capabilities_to_proto(
+    capabilities: &Capabilities,
+    project_id: u64,
+    client_id: u64,
+) -> SetDebugClientCapabilities {
+    SetDebugClientCapabilities {
+        client_id,
+        project_id,
+        supports_loaded_sources_request: capabilities
+            .supports_loaded_sources_request
+            .unwrap_or_default(),
+        supports_modules_request: capabilities.supports_modules_request.unwrap_or_default(),
+        supports_restart_request: capabilities.supports_restart_request.unwrap_or_default(),
+        supports_set_expression: capabilities.supports_set_expression.unwrap_or_default(),
+        supports_single_thread_execution_requests: capabilities
+            .supports_single_thread_execution_requests
+            .unwrap_or_default(),
+        supports_step_back: capabilities.supports_step_back.unwrap_or_default(),
+        supports_stepping_granularity: capabilities
+            .supports_stepping_granularity
+            .unwrap_or_default(),
+        supports_terminate_threads_request: capabilities
+            .supports_terminate_threads_request
+            .unwrap_or_default(),
     }
 }

--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -855,6 +855,8 @@ impl DebugPanel {
         debug_panel_item.update(cx, |this, cx| {
             this.from_proto(payload, cx);
         });
+
+        cx.notify();
     }
 
     fn handle_module_event(

--- a/crates/project/src/dap_store.rs
+++ b/crates/project/src/dap_store.rs
@@ -1483,13 +1483,15 @@ impl DapStore {
         envelope: TypedEnvelope<proto::SetDebugClientCapabilities>,
         mut cx: AsyncAppContext,
     ) -> Result<()> {
-        this.update(&mut cx, |dap_store, _| {
+        this.update(&mut cx, |dap_store, cx| {
             if dap_store.upstream_client().is_some() {
                 *dap_store
                     .capabilities
                     .entry(DebugAdapterClientId::from_proto(envelope.payload.client_id))
                     .or_default() =
                     dap::proto_conversions::capabilities_from_proto(&envelope.payload);
+
+                cx.notify();
             }
         })
     }

--- a/crates/proto/proto/zed.proto
+++ b/crates/proto/proto/zed.proto
@@ -312,7 +312,9 @@ message Envelope {
         SetActiveDebugLine set_active_debug_line = 292;
         RemoveActiveDebugLine remove_active_debug_line = 293;
         SetDebuggerPanelItem set_debugger_panel_item = 294;
-        UpdateDebugAdapter update_debug_adapter = 295; // current max
+        UpdateDebugAdapter update_debug_adapter = 295;
+        ShutdownDebugClient shutdown_debug_client = 296;
+        SetDebugClientCapabilities set_debug_client_capabilities = 297; // current max
     }
 
     reserved 87 to 88;
@@ -2415,6 +2417,24 @@ message RefreshLlmToken {}
 enum BreakpointKind {
     Standard = 0;
     Log = 1;
+}
+
+message ShutdownDebugClient {
+    uint64 client_id = 1;
+    uint64 project_id = 2;
+}
+
+message SetDebugClientCapabilities {
+uint64 client_id = 1;
+uint64 project_id = 2;
+bool supports_loaded_sources_request = 3;
+bool supports_modules_request = 4;
+bool supports_restart_request = 5;
+bool supports_set_expression = 6;
+bool supports_single_thread_execution_requests = 7;
+bool supports_step_back = 8;
+bool supports_stepping_granularity = 9;
+bool supports_terminate_threads_request = 10;
 }
 
 message Breakpoint {

--- a/crates/proto/src/proto.rs
+++ b/crates/proto/src/proto.rs
@@ -379,6 +379,8 @@ messages!(
     (SetActiveDebugLine, Background),
     (RemoveActiveDebugLine, Background),
     (SetDebuggerPanelItem, Background),
+    (ShutdownDebugClient, Background),
+    (SetDebugClientCapabilities, Background),
 );
 
 request_messages!(
@@ -597,6 +599,8 @@ entity_messages!(
     SetActiveDebugLine,
     RemoveActiveDebugLine,
     SetDebuggerPanelItem,
+    ShutdownDebugClient,
+    SetDebugClientCapabilities,
 );
 
 entity_messages!(


### PR DESCRIPTION
This PR aims to sync debug adapter clients during collaborative debugging. This should be done before working on the dap request proxy PR because some requests depend having on capabilities.

Todo
- [x] Sync capabilities on start up or capabilities changed event
- [x] Sync capabilities when ending debug sessions 

This also fixes Modules not rendering within the supported debug panel items!
<img width="1512" alt="Screenshot 2024-12-19 at 4 16 50 PM" src="https://github.com/user-attachments/assets/9d1f1667-191d-45fb-a709-28c4b8c501f8" />

