### PR TITLE
introduce debug session model

### DIFF
--- a/crates/collab/src/tests/debug_panel_tests.rs
+++ b/crates/collab/src/tests/debug_panel_tests.rs
@@ -76,7 +76,7 @@ async fn test_debug_panel_item_opens_on_remote(
 
     let task = project_a.update(cx_a, |project, cx| {
         project.dap_store().update(cx, |store, cx| {
-            store.start_test_debug_session(
+            store.start_debug_session(
                 dap::DebugAdapterConfig {
                     label: "test config".into(),
                     kind: dap::DebugAdapterKind::Fake,

--- a/crates/collab/src/tests/debug_panel_tests.rs
+++ b/crates/collab/src/tests/debug_panel_tests.rs
@@ -90,7 +90,7 @@ async fn test_debug_panel_item_opens_on_remote(
         })
     });
 
-    let (_session, client) = task.await.unwrap();
+    let (session, client) = task.await.unwrap();
 
     client
         .on_request::<Initialize, _>(move |_, _| {
@@ -145,7 +145,7 @@ async fn test_debug_panel_item_opens_on_remote(
 
     let shutdown_client = project_a.update(cx_a, |project, cx| {
         project.dap_store().update(cx, |dap_store, cx| {
-            dap_store.shutdown_client(&client.id(), cx)
+            dap_store.shutdown_session(&session.read(cx).id(), cx)
         })
     });
 

--- a/crates/collab/src/tests/debug_panel_tests.rs
+++ b/crates/collab/src/tests/debug_panel_tests.rs
@@ -76,7 +76,7 @@ async fn test_debug_panel_item_opens_on_remote(
 
     let task = project_a.update(cx_a, |project, cx| {
         project.dap_store().update(cx, |store, cx| {
-            store.start_test_client(
+            store.start_test_debug_session(
                 dap::DebugAdapterConfig {
                     label: "test config".into(),
                     kind: dap::DebugAdapterKind::Fake,
@@ -90,7 +90,7 @@ async fn test_debug_panel_item_opens_on_remote(
         })
     });
 
-    let client = task.await.unwrap();
+    let (_session, client) = task.await.unwrap();
 
     client
         .on_request::<Initialize, _>(move |_, _| {

--- a/crates/dap/src/client.rs
+++ b/crates/dap/src/client.rs
@@ -168,18 +168,13 @@ impl DebugAdapterClient {
             .await;
 
         log::debug!(
-            "Send `{}` request with sequence_id: {}",
+            "Client {} send `{}` request with sequence_id: {}",
+            self.id.0,
             R::COMMAND.to_string(),
             sequence_id
         );
 
         self.send_message(Message::Request(request)).await?;
-
-        log::debug!(
-            "Start receiving response for: `{}` sequence_id: {}",
-            R::COMMAND.to_string(),
-            sequence_id
-        );
 
         let mut timeout = self.executor.timer(DAP_REQUEST_TIMEOUT).fuse();
         let command = R::COMMAND.to_string();
@@ -187,7 +182,8 @@ impl DebugAdapterClient {
         select! {
             response = callback_rx.fuse() => {
                 log::debug!(
-                    "Received response for: `{}` sequence_id: {}",
+                    "Client {} received response for: `{}` sequence_id: {}",
+                    self.id.0,
                     command,
                     sequence_id
                 );

--- a/crates/dap/src/lib.rs
+++ b/crates/dap/src/lib.rs
@@ -2,6 +2,7 @@ pub mod adapters;
 pub mod client;
 pub mod debugger_settings;
 pub mod proto_conversions;
+pub mod session;
 pub mod transport;
 
 pub use dap_types::*;

--- a/crates/dap/src/proto_conversions.rs
+++ b/crates/dap/src/proto_conversions.rs
@@ -351,9 +351,11 @@ pub fn capabilities_from_proto(payload: &SetDebugClientCapabilities) -> Capabili
 pub fn capabilities_to_proto(
     capabilities: &Capabilities,
     project_id: u64,
+    session_id: u64,
     client_id: u64,
 ) -> SetDebugClientCapabilities {
     SetDebugClientCapabilities {
+        session_id,
         client_id,
         project_id,
         supports_loaded_sources_request: capabilities

--- a/crates/dap/src/session.rs
+++ b/crates/dap/src/session.rs
@@ -23,6 +23,7 @@ impl DebugSessionId {
 
 pub struct DebugSession {
     id: DebugSessionId,
+    ignore_breakpoints: bool,
     configuration: DebugAdapterConfig,
     capabilities: HashMap<DebugAdapterClientId, Capabilities>,
     clients: HashMap<DebugAdapterClientId, Arc<DebugAdapterClient>>,
@@ -33,6 +34,7 @@ impl DebugSession {
         Self {
             id,
             configuration,
+            ignore_breakpoints: false,
             clients: HashMap::default(),
             capabilities: HashMap::default(),
         }
@@ -48,6 +50,15 @@ impl DebugSession {
 
     pub fn configuration(&self) -> &DebugAdapterConfig {
         &self.configuration
+    }
+
+    pub fn ignore_breakpoints(&self) -> bool {
+        self.ignore_breakpoints
+    }
+
+    pub fn set_ignore_breakpoints(&mut self, ignore: bool, cx: &mut ModelContext<Self>) {
+        self.ignore_breakpoints = ignore;
+        cx.notify();
     }
 
     pub fn update_configuration(

--- a/crates/dap/src/session.rs
+++ b/crates/dap/src/session.rs
@@ -97,8 +97,11 @@ impl DebugSession {
 
     pub fn shutdown_clients(&self, cx: &mut ModelContext<Self>) -> Task<Result<()>> {
         let mut tasks = Vec::new();
-        for client in self.clients.values().cloned() {
-            tasks.push(cx.spawn(|_, _| async move { client.shutdown().await }));
+        for client in self.clients.values() {
+            tasks.push(cx.spawn({
+                let client = client.clone();
+                |_, _| async move { client.shutdown().await }
+            }));
         }
 
         cx.background_executor().spawn(async move {

--- a/crates/dap/src/session.rs
+++ b/crates/dap/src/session.rs
@@ -97,19 +97,4 @@ impl DebugSession {
     pub fn clients(&self) -> impl Iterator<Item = Arc<DebugAdapterClient>> + '_ {
         self.clients.values().cloned()
     }
-
-    pub fn shutdown_clients(&self, cx: &mut ModelContext<Self>) -> Task<Result<()>> {
-        let mut tasks = Vec::new();
-        for client in self.clients.values() {
-            tasks.push(cx.spawn({
-                let client = client.clone();
-                |_, _| async move { client.shutdown().await }
-            }));
-        }
-
-        cx.background_executor().spawn(async move {
-            futures::future::join_all(tasks).await;
-            Ok(())
-        })
-    }
 }

--- a/crates/dap/src/session.rs
+++ b/crates/dap/src/session.rs
@@ -1,5 +1,7 @@
+use anyhow::Result;
 use collections::HashMap;
 use dap_types::Capabilities;
+use gpui::{ModelContext, Task};
 use std::sync::Arc;
 use task::DebugAdapterConfig;
 
@@ -8,6 +10,16 @@ use crate::client::{DebugAdapterClient, DebugAdapterClientId};
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(transparent)]
 pub struct DebugSessionId(pub usize);
+
+impl DebugSessionId {
+    pub fn from_proto(client_id: u64) -> Self {
+        Self(client_id as usize)
+    }
+
+    pub fn to_proto(&self) -> u64 {
+        self.0 as u64
+    }
+}
 
 pub struct DebugSession {
     id: DebugSessionId,
@@ -38,6 +50,10 @@ impl DebugSession {
         &self.configuration
     }
 
+    pub fn update_configuration(&mut self, f: impl FnOnce(&mut DebugAdapterConfig)) {
+        f(&mut self.configuration);
+    }
+
     pub fn capabilities(&self, client_id: &DebugAdapterClientId) -> Capabilities {
         self.capabilities
             .get(client_id)
@@ -45,12 +61,27 @@ impl DebugSession {
             .unwrap_or_default()
     }
 
+    pub fn update_capabilities(
+        &mut self,
+        client_id: &DebugAdapterClientId,
+        new_capabilities: Capabilities,
+    ) {
+        if let Some(capabilities) = self.capabilities.get_mut(client_id) {
+            *capabilities = capabilities.merge(new_capabilities);
+        } else {
+            self.capabilities.insert(*client_id, new_capabilities);
+        }
+    }
+
     pub fn add_client(&mut self, client: Arc<DebugAdapterClient>) {
         self.clients.insert(client.id(), client);
     }
 
-    pub fn remove_client(&mut self, client_id: &DebugAdapterClientId) {
-        self.clients.remove(client_id);
+    pub fn remove_client(
+        &mut self,
+        client_id: &DebugAdapterClientId,
+    ) -> Option<Arc<DebugAdapterClient>> {
+        self.clients.remove(client_id)
     }
 
     pub fn client_by_id(
@@ -62,5 +93,17 @@ impl DebugSession {
 
     pub fn clients(&self) -> impl Iterator<Item = Arc<DebugAdapterClient>> + '_ {
         self.clients.values().cloned()
+    }
+
+    pub fn shutdown_clients(&self, cx: &mut ModelContext<Self>) -> Task<Result<()>> {
+        let mut tasks = Vec::new();
+        for client in self.clients.values().cloned() {
+            tasks.push(cx.spawn(|_, _| async move { client.shutdown().await }));
+        }
+
+        cx.background_executor().spawn(async move {
+            futures::future::join_all(tasks).await;
+            Ok(())
+        })
     }
 }

--- a/crates/dap/src/session.rs
+++ b/crates/dap/src/session.rs
@@ -90,6 +90,10 @@ impl DebugSession {
         self.clients.get(client_id).cloned()
     }
 
+    pub fn has_clients(&self) -> bool {
+        !self.clients.is_empty()
+    }
+
     pub fn clients(&self) -> impl Iterator<Item = Arc<DebugAdapterClient>> + '_ {
         self.clients.values().cloned()
     }

--- a/crates/dap/src/session.rs
+++ b/crates/dap/src/session.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 use collections::HashMap;
-use dap_types::Capabilities;
 use gpui::{ModelContext, Task};
 use std::sync::Arc;
 use task::DebugAdapterConfig;
@@ -25,7 +24,6 @@ pub struct DebugSession {
     id: DebugSessionId,
     ignore_breakpoints: bool,
     configuration: DebugAdapterConfig,
-    capabilities: HashMap<DebugAdapterClientId, Capabilities>,
     clients: HashMap<DebugAdapterClientId, Arc<DebugAdapterClient>>,
 }
 
@@ -36,7 +34,6 @@ impl DebugSession {
             configuration,
             ignore_breakpoints: false,
             clients: HashMap::default(),
-            capabilities: HashMap::default(),
         }
     }
 
@@ -67,28 +64,6 @@ impl DebugSession {
         cx: &mut ModelContext<Self>,
     ) {
         f(&mut self.configuration);
-        cx.notify();
-    }
-
-    pub fn capabilities(&self, client_id: &DebugAdapterClientId) -> Capabilities {
-        self.capabilities
-            .get(client_id)
-            .cloned()
-            .unwrap_or_default()
-    }
-
-    pub fn update_capabilities(
-        &mut self,
-        client_id: &DebugAdapterClientId,
-        new_capabilities: Capabilities,
-        cx: &mut ModelContext<Self>,
-    ) {
-        if let Some(capabilities) = self.capabilities.get_mut(client_id) {
-            *capabilities = capabilities.merge(new_capabilities);
-        } else {
-            self.capabilities.insert(*client_id, new_capabilities);
-        }
-
         cx.notify();
     }
 

--- a/crates/dap/src/session.rs
+++ b/crates/dap/src/session.rs
@@ -1,0 +1,66 @@
+use collections::HashMap;
+use dap_types::Capabilities;
+use std::sync::Arc;
+use task::DebugAdapterConfig;
+
+use crate::client::{DebugAdapterClient, DebugAdapterClientId};
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
+pub struct DebugSessionId(pub usize);
+
+pub struct DebugSession {
+    id: DebugSessionId,
+    configuration: DebugAdapterConfig,
+    capabilities: HashMap<DebugAdapterClientId, Capabilities>,
+    clients: HashMap<DebugAdapterClientId, Arc<DebugAdapterClient>>,
+}
+
+impl DebugSession {
+    pub fn new(id: DebugSessionId, configuration: DebugAdapterConfig) -> Self {
+        Self {
+            id,
+            configuration,
+            clients: HashMap::default(),
+            capabilities: HashMap::default(),
+        }
+    }
+
+    pub fn id(&self) -> DebugSessionId {
+        self.id
+    }
+
+    pub fn name(&self) -> String {
+        self.configuration.label.clone()
+    }
+
+    pub fn configuration(&self) -> &DebugAdapterConfig {
+        &self.configuration
+    }
+
+    pub fn capabilities(&self, client_id: &DebugAdapterClientId) -> Capabilities {
+        self.capabilities
+            .get(client_id)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    pub fn add_client(&mut self, client: Arc<DebugAdapterClient>) {
+        self.clients.insert(client.id(), client);
+    }
+
+    pub fn remove_client(&mut self, client_id: &DebugAdapterClientId) {
+        self.clients.remove(client_id);
+    }
+
+    pub fn client_by_id(
+        &self,
+        client_id: &DebugAdapterClientId,
+    ) -> Option<Arc<DebugAdapterClient>> {
+        self.clients.get(client_id).cloned()
+    }
+
+    pub fn clients(&self) -> impl Iterator<Item = Arc<DebugAdapterClient>> + '_ {
+        self.clients.values().cloned()
+    }
+}

--- a/crates/dap/src/session.rs
+++ b/crates/dap/src/session.rs
@@ -1,6 +1,5 @@
-use anyhow::Result;
 use collections::HashMap;
-use gpui::{ModelContext, Task};
+use gpui::ModelContext;
 use std::sync::Arc;
 use task::DebugAdapterConfig;
 

--- a/crates/debugger_tools/src/dap_log.rs
+++ b/crates/debugger_tools/src/dap_log.rs
@@ -411,7 +411,7 @@ impl Render for DapLogToolbarItemView {
                         for sub_item in row.clients.into_iter() {
                             menu = menu.label(format!(
                                 "{}. {}",
-                                sub_item.client_name, sub_item.client_id.0
+                                sub_item.client_id.0, sub_item.client_name,
                             ));
 
                             if sub_item.has_adapter_logs {

--- a/crates/debugger_tools/src/dap_log.rs
+++ b/crates/debugger_tools/src/dap_log.rs
@@ -25,7 +25,7 @@ use util::maybe;
 use workspace::{
     item::Item,
     searchable::{SearchEvent, SearchableItem, SearchableItemHandle},
-    ui::{h_flex, Button, Clickable, ContextMenu, Label, PopoverMenu},
+    ui::{h_flex, Button, Clickable, ContextMenu, Label, LabelCommon, PopoverMenu},
     ToolbarItemEvent, ToolbarItemView, Workspace,
 };
 
@@ -391,8 +391,9 @@ impl Render for DapLogToolbarItemView {
                 current_client
                     .map(|sub_item| {
                         Cow::Owned(format!(
-                            "{} - {}",
+                            "{} ({}) - {}",
                             sub_item.client_name,
+                            sub_item.client_id.0,
                             match sub_item.selected_entry {
                                 LogKind::Adapter => ADAPTER_LOGS,
                                 LogKind::Rpc => RPC_MESSAGES,
@@ -409,15 +410,29 @@ impl Render for DapLogToolbarItemView {
                         menu = menu.header(format!("{}. {}", row.session_id.0, row.session_name));
 
                         for sub_item in row.clients.into_iter() {
-                            menu = menu.label(format!(
-                                "{}. {}",
-                                sub_item.client_id.0, sub_item.client_name,
-                            ));
+                            menu = menu.custom_row(move |_| {
+                                div()
+                                    .w_full()
+                                    .pl_2()
+                                    .child(
+                                        Label::new(format!(
+                                            "{}. {}",
+                                            sub_item.client_id.0, sub_item.client_name,
+                                        ))
+                                        .color(workspace::ui::Color::Muted),
+                                    )
+                                    .into_any_element()
+                            });
 
                             if sub_item.has_adapter_logs {
-                                menu = menu.entry(
-                                    ADAPTER_LOGS,
-                                    None,
+                                menu = menu.custom_entry(
+                                    move |_| {
+                                        div()
+                                            .w_full()
+                                            .pl_4()
+                                            .child(Label::new(ADAPTER_LOGS))
+                                            .into_any_element()
+                                    },
                                     cx.handler_for(&log_view, move |view, cx| {
                                         view.show_log_messages_for_server(sub_item.client_id, cx);
                                     }),
@@ -426,9 +441,9 @@ impl Render for DapLogToolbarItemView {
 
                             menu = menu.custom_entry(
                                 move |_| {
-                                    h_flex()
+                                    div()
                                         .w_full()
-                                        .justify_between()
+                                        .pl_4()
                                         .child(Label::new(RPC_MESSAGES))
                                         .into_any_element()
                                 },

--- a/crates/debugger_tools/src/dap_log.rs
+++ b/crates/debugger_tools/src/dap_log.rs
@@ -394,9 +394,8 @@ impl Render for DapLogToolbarItemView {
                 current_client
                     .map(|sub_item| {
                         Cow::Owned(format!(
-                            "{}({}) - {}",
+                            "{} - {}",
                             sub_item.client_name,
-                            sub_item.client_id.0,
                             match sub_item.selected_entry {
                                 LogKind::Adapter => ADAPTER_LOGS,
                                 LogKind::Rpc => RPC_MESSAGES,

--- a/crates/debugger_tools/src/dap_log.rs
+++ b/crates/debugger_tools/src/dap_log.rs
@@ -170,7 +170,11 @@ impl LogStore {
                         project::Event::DebugClientStarted(client_id) => {
                             this.add_debug_client(
                                 *client_id,
-                                project.read(cx).debug_client_for_id(client_id, cx),
+                                project.update(cx, |project, cx| {
+                                    project
+                                        .dap_store()
+                                        .update(cx, |store, cx| store.client_by_id(client_id, cx))
+                                }),
                             );
                         }
                         project::Event::DebugClientShutdown(id) => {

--- a/crates/debugger_tools/src/dap_log.rs
+++ b/crates/debugger_tools/src/dap_log.rs
@@ -583,18 +583,22 @@ impl DapLogView {
                 .map(|session| DapMenuItem {
                     session_id: session.read(cx).id(),
                     session_name: session.read(cx).name(),
-                    clients: session
-                        .read(cx)
-                        .clients()
-                        .map(|client| DapMenuSubItem {
-                            client_id: client.id(),
-                            client_name: client.adapter_id(),
-                            has_adapter_logs: client.has_adapter_logs(),
-                            selected_entry: self
-                                .current_view
-                                .map_or(LogKind::Adapter, |(_, kind)| kind),
-                        })
-                        .collect::<Vec<_>>(),
+                    clients: {
+                        let mut clients = session
+                            .read(cx)
+                            .clients()
+                            .map(|client| DapMenuSubItem {
+                                client_id: client.id(),
+                                client_name: client.adapter_id(),
+                                has_adapter_logs: client.has_adapter_logs(),
+                                selected_entry: self
+                                    .current_view
+                                    .map_or(LogKind::Adapter, |(_, kind)| kind),
+                            })
+                            .collect::<Vec<_>>();
+                        clients.sort_by_key(|item| item.client_id.0);
+                        clients
+                    },
                 })
                 .collect::<Vec<_>>(),
         )

--- a/crates/debugger_tools/src/dap_log.rs
+++ b/crates/debugger_tools/src/dap_log.rs
@@ -574,34 +574,35 @@ impl DapLogView {
     }
 
     fn menu_items(&self, cx: &AppContext) -> Option<Vec<DapMenuItem>> {
-        Some(
-            self.project
-                .read(cx)
-                .dap_store()
-                .read(cx)
-                .sessions()
-                .map(|session| DapMenuItem {
-                    session_id: session.read(cx).id(),
-                    session_name: session.read(cx).name(),
-                    clients: {
-                        let mut clients = session
-                            .read(cx)
-                            .clients()
-                            .map(|client| DapMenuSubItem {
-                                client_id: client.id(),
-                                client_name: client.adapter_id(),
-                                has_adapter_logs: client.has_adapter_logs(),
-                                selected_entry: self
-                                    .current_view
-                                    .map_or(LogKind::Adapter, |(_, kind)| kind),
-                            })
-                            .collect::<Vec<_>>();
-                        clients.sort_by_key(|item| item.client_id.0);
-                        clients
-                    },
-                })
-                .collect::<Vec<_>>(),
-        )
+        let mut menu_items = self
+            .project
+            .read(cx)
+            .dap_store()
+            .read(cx)
+            .sessions()
+            .map(|session| DapMenuItem {
+                session_id: session.read(cx).id(),
+                session_name: session.read(cx).name(),
+                clients: {
+                    let mut clients = session
+                        .read(cx)
+                        .clients()
+                        .map(|client| DapMenuSubItem {
+                            client_id: client.id(),
+                            client_name: client.adapter_id(),
+                            has_adapter_logs: client.has_adapter_logs(),
+                            selected_entry: self
+                                .current_view
+                                .map_or(LogKind::Adapter, |(_, kind)| kind),
+                        })
+                        .collect::<Vec<_>>();
+                    clients.sort_by_key(|item| item.client_id.0);
+                    clients
+                },
+            })
+            .collect::<Vec<_>>();
+        menu_items.sort_by_key(|item| item.session_id.0);
+        Some(menu_items)
     }
 
     fn show_rpc_trace_for_server(

--- a/crates/debugger_ui/src/attach_modal.rs
+++ b/crates/debugger_ui/src/attach_modal.rs
@@ -112,12 +112,9 @@ impl PickerDelegate for AttachModalDelegate {
                     if let Some(processes) = this.delegate.candidates.clone() {
                         processes
                     } else {
-                        let Some(client) = this
-                            .delegate
-                            .dap_store
-                            .read(cx)
-                            .client_by_id(&this.delegate.client_id)
-                        else {
+                        let Some(client) = this.delegate.dap_store.update(cx, |store, cx| {
+                            store.client_by_id(&this.delegate.client_id, cx)
+                        }) else {
                             return Vec::new();
                         };
 

--- a/crates/debugger_ui/src/attach_modal.rs
+++ b/crates/debugger_ui/src/attach_modal.rs
@@ -1,4 +1,5 @@
 use dap::client::DebugAdapterClientId;
+use dap::session::DebugSessionId;
 use fuzzy::{StringMatch, StringMatchCandidate};
 use gpui::{DismissEvent, EventEmitter, FocusableView, Render, View};
 use gpui::{Model, Subscription};
@@ -20,6 +21,7 @@ struct Candidate {
 struct AttachModalDelegate {
     selected_index: usize,
     matches: Vec<StringMatch>,
+    session_id: DebugSessionId,
     placeholder_text: Arc<str>,
     dap_store: Model<DapStore>,
     client_id: DebugAdapterClientId,
@@ -27,10 +29,15 @@ struct AttachModalDelegate {
 }
 
 impl AttachModalDelegate {
-    pub fn new(client_id: DebugAdapterClientId, dap_store: Model<DapStore>) -> Self {
+    pub fn new(
+        session_id: DebugSessionId,
+        client_id: DebugAdapterClientId,
+        dap_store: Model<DapStore>,
+    ) -> Self {
         Self {
             client_id,
             dap_store,
+            session_id,
             candidates: None,
             selected_index: 0,
             matches: Vec::default(),
@@ -46,12 +53,16 @@ pub(crate) struct AttachModal {
 
 impl AttachModal {
     pub fn new(
+        session_id: &DebugSessionId,
         client_id: &DebugAdapterClientId,
         dap_store: Model<DapStore>,
         cx: &mut ViewContext<Self>,
     ) -> Self {
         let picker = cx.new_view(|cx| {
-            Picker::uniform_list(AttachModalDelegate::new(*client_id, dap_store), cx)
+            Picker::uniform_list(
+                AttachModalDelegate::new(*session_id, *client_id, dap_store),
+                cx,
+            )
         });
         let _subscription = cx.subscribe(&picker, |_, _, _, cx| {
             cx.emit(DismissEvent);
@@ -200,7 +211,7 @@ impl PickerDelegate for AttachModalDelegate {
 
         self.dap_store.update(cx, |store, cx| {
             store
-                .attach(&self.client_id, candidate.pid, cx)
+                .attach(&self.session_id, &self.client_id, candidate.pid, cx)
                 .detach_and_log_err(cx);
         });
 

--- a/crates/debugger_ui/src/attach_modal.rs
+++ b/crates/debugger_ui/src/attach_modal.rs
@@ -123,7 +123,7 @@ impl PickerDelegate for AttachModalDelegate {
                     if let Some(processes) = this.delegate.candidates.clone() {
                         processes
                     } else {
-                        let Some(client) = this.delegate.dap_store.update(cx, |store, cx| {
+                        let Some((_, client)) = this.delegate.dap_store.update(cx, |store, cx| {
                             store.client_by_id(&this.delegate.client_id, cx)
                         }) else {
                             return Vec::new();

--- a/crates/debugger_ui/src/attach_modal.rs
+++ b/crates/debugger_ui/src/attach_modal.rs
@@ -223,7 +223,7 @@ impl PickerDelegate for AttachModalDelegate {
         self.candidates.take();
 
         self.dap_store.update(cx, |store, cx| {
-            store.shutdown_client(&self.client_id, cx).detach();
+            store.shutdown_session(&self.session_id, cx).detach();
         });
 
         cx.emit(DismissEvent);

--- a/crates/debugger_ui/src/console.rs
+++ b/crates/debugger_ui/src/console.rs
@@ -223,7 +223,7 @@ impl CompletionProvider for ConsoleQueryBarCompletionProvider {
 
         let support_completions = console.update(cx, |this, cx| {
             this.dap_store
-                .read_with(cx, |store, cx| {
+                .update(cx, |store, cx| {
                     store.capabilities_by_id(&this.client_id, cx)
                 })
                 .supports_completions_request

--- a/crates/debugger_ui/src/console.rs
+++ b/crates/debugger_ui/src/console.rs
@@ -223,8 +223,9 @@ impl CompletionProvider for ConsoleQueryBarCompletionProvider {
 
         let support_completions = console.update(cx, |this, cx| {
             this.dap_store
-                .read(cx)
-                .capabilities_by_id(&this.client_id)
+                .read_with(cx, |store, cx| {
+                    store.capabilities_by_id(&this.client_id, cx)
+                })
                 .supports_completions_request
                 .unwrap_or_default()
         });

--- a/crates/debugger_ui/src/console.rs
+++ b/crates/debugger_ui/src/console.rs
@@ -221,14 +221,13 @@ impl CompletionProvider for ConsoleQueryBarCompletionProvider {
             return Task::ready(Ok(Vec::new()));
         };
 
-        let support_completions = console.update(cx, |this, cx| {
-            this.dap_store
-                .update(cx, |store, cx| {
-                    store.capabilities_by_id(&this.client_id, cx)
-                })
-                .supports_completions_request
-                .unwrap_or_default()
-        });
+        let support_completions = console
+            .read(cx)
+            .dap_store
+            .read(cx)
+            .capabilities_by_id(&console.read(cx).client_id)
+            .supports_completions_request
+            .unwrap_or_default();
 
         if support_completions {
             self.client_completions(&console, buffer, buffer_position, cx)

--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -473,7 +473,10 @@ impl DebugPanel {
         client_id: &DebugAdapterClientId,
         cx: &mut ViewContext<Self>,
     ) {
-        let Some(client) = self.dap_store.read(cx).client_by_id(&client_id) else {
+        let Some(client) = self
+            .dap_store
+            .update(cx, |store, cx| store.client_by_id(&client_id, cx))
+        else {
             return;
         };
 
@@ -604,8 +607,7 @@ impl DebugPanel {
 
         let Some(client_name) = self
             .dap_store
-            .read(cx)
-            .client_by_id(client_id)
+            .update(cx, |store, cx| store.client_by_id(client_id, cx))
             .map(|client| client.config().label)
         else {
             return; // this can never happen

--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -181,7 +181,7 @@ impl DebugPanel {
                             }
                             _ => unreachable!(),
                         },
-                        project::Event::DebugClientShutdown((session_id, client_id)) => {
+                        project::Event::DebugClientShutdown(client_id) => {
                             cx.emit(DebugPanelEvent::ClientShutdown(*client_id));
 
                             this.message_queue.remove(client_id);

--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -582,7 +582,7 @@ impl DebugPanel {
     ) {
         if let Some(capabilities) = capabilities {
             self.dap_store.update(cx, |store, cx| {
-                store.merge_capabilities_for_client(&session_id, &client_id, capabilities, cx);
+                store.update_capabilities_for_client(&session_id, &client_id, capabilities, cx);
             });
 
             cx.emit(DebugPanelEvent::CapabilitiesChanged(*client_id));
@@ -923,7 +923,7 @@ impl DebugPanel {
         cx: &mut ViewContext<Self>,
     ) {
         self.dap_store.update(cx, |store, cx| {
-            store.merge_capabilities_for_client(session_id, client_id, &event.capabilities, cx);
+            store.update_capabilities_for_client(session_id, client_id, &event.capabilities, cx);
         });
 
         cx.emit(DebugPanelEvent::CapabilitiesChanged(*client_id));

--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -548,7 +548,9 @@ impl DebugPanel {
         cx: &mut ViewContext<Self>,
     ) {
         match event {
-            Events::Initialized(event) => self.handle_initialized_event(&client_id, event, cx),
+            Events::Initialized(event) => {
+                self.handle_initialized_event(&session_id, &client_id, event, cx)
+            }
             Events::Stopped(event) => self.handle_stopped_event(&session_id, &client_id, event, cx),
             Events::Continued(event) => self.handle_continued_event(&client_id, event, cx),
             Events::Exited(event) => self.handle_exited_event(&client_id, event, cx),
@@ -573,6 +575,7 @@ impl DebugPanel {
 
     fn handle_initialized_event(
         &mut self,
+        session_id: &DebugSessionId,
         client_id: &DebugAdapterClientId,
         capabilities: &Option<Capabilities>,
         cx: &mut ViewContext<Self>,
@@ -586,9 +589,9 @@ impl DebugPanel {
         }
 
         let send_breakpoints_task = self.workspace.update(cx, |workspace, cx| {
-            workspace
-                .project()
-                .update(cx, |project, cx| project.send_breakpoints(&client_id, cx))
+            workspace.project().update(cx, |project, cx| {
+                project.send_breakpoints(&session_id, &client_id, cx)
+            })
         });
 
         let configuration_done_task = self

--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -561,7 +561,7 @@ impl DebugPanel {
             Events::Module(event) => self.handle_module_event(&client_id, event, cx),
             Events::LoadedSource(event) => self.handle_loaded_source_event(&client_id, event, cx),
             Events::Capabilities(event) => {
-                self.handle_capabilities_changed_event(client_id, event, cx);
+                self.handle_capabilities_changed_event(session_id, client_id, event, cx);
             }
             Events::Memory(_) => {}
             Events::Process(_) => {}
@@ -582,7 +582,7 @@ impl DebugPanel {
     ) {
         if let Some(capabilities) = capabilities {
             self.dap_store.update(cx, |store, cx| {
-                store.merge_capabilities_for_client(&client_id, capabilities, cx);
+                store.merge_capabilities_for_client(&session_id, &client_id, capabilities, cx);
             });
 
             cx.emit(DebugPanelEvent::CapabilitiesChanged(*client_id));
@@ -917,12 +917,13 @@ impl DebugPanel {
 
     fn handle_capabilities_changed_event(
         &mut self,
+        session_id: &DebugSessionId,
         client_id: &DebugAdapterClientId,
         event: &CapabilitiesEvent,
         cx: &mut ViewContext<Self>,
     ) {
         self.dap_store.update(cx, |store, cx| {
-            store.merge_capabilities_for_client(client_id, &event.capabilities, cx);
+            store.merge_capabilities_for_client(session_id, client_id, &event.capabilities, cx);
         });
 
         cx.emit(DebugPanelEvent::CapabilitiesChanged(*client_id));

--- a/crates/debugger_ui/src/debugger_panel_item.rs
+++ b/crates/debugger_ui/src/debugger_panel_item.rs
@@ -672,7 +672,7 @@ impl DebugPanelItem {
             .update(cx, |workspace, cx| {
                 workspace.project().update(cx, |project, cx| {
                     project
-                        .toggle_ignore_breakpoints(&self.client_id, cx)
+                        .toggle_ignore_breakpoints(&self.session_id, &self.client_id, cx)
                         .detach_and_log_err(cx);
                 })
             })
@@ -903,7 +903,9 @@ impl Render for DebugPanelItem {
                             .child(
                                 IconButton::new(
                                     "debug-ignore-breakpoints",
-                                    if self.dap_store.read(cx).ignore_breakpoints(&self.client_id) {
+                                    if self.dap_store.update(cx, |store, cx| {
+                                        store.ignore_breakpoints(&self.session_id, cx)
+                                    }) {
                                         IconName::DebugIgnoreBreakpoints
                                     } else {
                                         IconName::DebugBreakpoint

--- a/crates/debugger_ui/src/debugger_panel_item.rs
+++ b/crates/debugger_ui/src/debugger_panel_item.rs
@@ -472,6 +472,10 @@ impl DebugPanelItem {
         }
     }
 
+    pub fn session_id(&self) -> DebugSessionId {
+        self.session_id
+    }
+
     pub fn client_id(&self) -> DebugAdapterClientId {
         self.client_id
     }
@@ -651,7 +655,12 @@ impl DebugPanelItem {
     pub fn stop_thread(&self, cx: &mut ViewContext<Self>) {
         self.dap_store.update(cx, |store, cx| {
             store
-                .terminate_threads(&self.client_id, Some(vec![self.thread_id; 1]), cx)
+                .terminate_threads(
+                    &self.session_id,
+                    &self.client_id,
+                    Some(vec![self.thread_id; 1]),
+                    cx,
+                )
                 .detach_and_log_err(cx)
         });
     }

--- a/crates/debugger_ui/src/lib.rs
+++ b/crates/debugger_ui/src/lib.rs
@@ -38,7 +38,7 @@ pub fn init(cx: &mut AppContext) {
                 .register_action(|workspace: &mut Workspace, _: &ShutdownDebugAdapters, cx| {
                     workspace.project().update(cx, |project, cx| {
                         project.dap_store().update(cx, |store, cx| {
-                            store.shutdown_clients(cx).detach();
+                            store.shutdown_sessions(cx).detach();
                         })
                     })
                 })

--- a/crates/debugger_ui/src/tests/console.rs
+++ b/crates/debugger_ui/src/tests/console.rs
@@ -50,7 +50,7 @@ async fn test_evaluate_expression(executor: BackgroundExecutor, cx: &mut TestApp
 
     let task = project.update(cx, |project, cx| {
         project.dap_store().update(cx, |store, cx| {
-            store.start_test_client(
+            store.start_test_debug_session(
                 task::DebugAdapterConfig {
                     label: "test config".into(),
                     kind: task::DebugAdapterKind::Fake,
@@ -64,7 +64,7 @@ async fn test_evaluate_expression(executor: BackgroundExecutor, cx: &mut TestApp
         })
     });
 
-    let client = task.await.unwrap();
+    let (_session, client) = task.await.unwrap();
 
     client
         .on_request::<Initialize, _>(move |_, _| {

--- a/crates/debugger_ui/src/tests/console.rs
+++ b/crates/debugger_ui/src/tests/console.rs
@@ -64,7 +64,7 @@ async fn test_evaluate_expression(executor: BackgroundExecutor, cx: &mut TestApp
         })
     });
 
-    let (_session, client) = task.await.unwrap();
+    let (session, client) = task.await.unwrap();
 
     client
         .on_request::<Initialize, _>(move |_, _| {
@@ -455,7 +455,7 @@ async fn test_evaluate_expression(executor: BackgroundExecutor, cx: &mut TestApp
 
     let shutdown_client = project.update(cx, |project, cx| {
         project.dap_store().update(cx, |dap_store, cx| {
-            dap_store.shutdown_client(&client.id(), cx)
+            dap_store.shutdown_session(&session.read(cx).id(), cx)
         })
     });
 

--- a/crates/debugger_ui/src/tests/console.rs
+++ b/crates/debugger_ui/src/tests/console.rs
@@ -50,7 +50,7 @@ async fn test_evaluate_expression(executor: BackgroundExecutor, cx: &mut TestApp
 
     let task = project.update(cx, |project, cx| {
         project.dap_store().update(cx, |store, cx| {
-            store.start_test_debug_session(
+            store.start_debug_session(
                 task::DebugAdapterConfig {
                     label: "test config".into(),
                     kind: task::DebugAdapterKind::Fake,

--- a/crates/debugger_ui/src/tests/debugger_panel.rs
+++ b/crates/debugger_ui/src/tests/debugger_panel.rs
@@ -31,7 +31,7 @@ async fn test_basic_show_debug_panel(executor: BackgroundExecutor, cx: &mut Test
         })
     });
 
-    let (_session, client) = task.await.unwrap();
+    let (session, client) = task.await.unwrap();
 
     client
         .on_request::<Initialize, _>(move |_, _| {
@@ -100,7 +100,7 @@ async fn test_basic_show_debug_panel(executor: BackgroundExecutor, cx: &mut Test
 
     let shutdown_client = project.update(cx, |project, cx| {
         project.dap_store().update(cx, |dap_store, cx| {
-            dap_store.shutdown_client(&client.id(), cx)
+            dap_store.shutdown_session(&session.read(cx).id(), cx)
         })
     });
 
@@ -148,7 +148,7 @@ async fn test_we_can_only_have_one_panel_per_debug_thread(
         })
     });
 
-    let (_session, client) = task.await.unwrap();
+    let (session, client) = task.await.unwrap();
 
     client
         .on_request::<Initialize, _>(move |_, _| {
@@ -248,7 +248,7 @@ async fn test_we_can_only_have_one_panel_per_debug_thread(
 
     let shutdown_client = project.update(cx, |project, cx| {
         project.dap_store().update(cx, |dap_store, cx| {
-            dap_store.shutdown_client(&client.id(), cx)
+            dap_store.shutdown_session(&session.read(cx).id(), cx)
         })
     });
 
@@ -296,7 +296,7 @@ async fn test_client_can_open_multiple_thread_panels(
         })
     });
 
-    let (_session, client) = task.await.unwrap();
+    let (session, client) = task.await.unwrap();
 
     client
         .on_request::<Initialize, _>(move |_, _| {
@@ -396,7 +396,7 @@ async fn test_client_can_open_multiple_thread_panels(
 
     let shutdown_client = project.update(cx, |project, cx| {
         project.dap_store().update(cx, |dap_store, cx| {
-            dap_store.shutdown_client(&client.id(), cx)
+            dap_store.shutdown_session(&session.read(cx).id(), cx)
         })
     });
 
@@ -441,7 +441,7 @@ async fn test_handle_output_event(executor: BackgroundExecutor, cx: &mut TestApp
         })
     });
 
-    let (_session, client) = task.await.unwrap();
+    let (session, client) = task.await.unwrap();
 
     client
         .on_request::<Initialize, _>(move |_, _| {
@@ -555,7 +555,7 @@ async fn test_handle_output_event(executor: BackgroundExecutor, cx: &mut TestApp
 
     let shutdown_client = project.update(cx, |project, cx| {
         project.dap_store().update(cx, |dap_store, cx| {
-            dap_store.shutdown_client(&client.id(), cx)
+            dap_store.shutdown_session(&session.read(cx).id(), cx)
         })
     });
 

--- a/crates/debugger_ui/src/tests/debugger_panel.rs
+++ b/crates/debugger_ui/src/tests/debugger_panel.rs
@@ -17,7 +17,7 @@ async fn test_basic_show_debug_panel(executor: BackgroundExecutor, cx: &mut Test
 
     let task = project.update(cx, |project, cx| {
         project.dap_store().update(cx, |store, cx| {
-            store.start_test_client(
+            store.start_test_debug_session(
                 task::DebugAdapterConfig {
                     label: "test config".into(),
                     kind: task::DebugAdapterKind::Fake,
@@ -31,7 +31,7 @@ async fn test_basic_show_debug_panel(executor: BackgroundExecutor, cx: &mut Test
         })
     });
 
-    let client = task.await.unwrap();
+    let (_session, client) = task.await.unwrap();
 
     client
         .on_request::<Initialize, _>(move |_, _| {
@@ -134,7 +134,7 @@ async fn test_we_can_only_have_one_panel_per_debug_thread(
 
     let task = project.update(cx, |project, cx| {
         project.dap_store().update(cx, |store, cx| {
-            store.start_test_client(
+            store.start_test_debug_session(
                 task::DebugAdapterConfig {
                     label: "test config".into(),
                     kind: task::DebugAdapterKind::Fake,
@@ -148,7 +148,7 @@ async fn test_we_can_only_have_one_panel_per_debug_thread(
         })
     });
 
-    let client = task.await.unwrap();
+    let (_session, client) = task.await.unwrap();
 
     client
         .on_request::<Initialize, _>(move |_, _| {
@@ -282,7 +282,7 @@ async fn test_client_can_open_multiple_thread_panels(
 
     let task = project.update(cx, |project, cx| {
         project.dap_store().update(cx, |store, cx| {
-            store.start_test_client(
+            store.start_test_debug_session(
                 task::DebugAdapterConfig {
                     label: "test config".into(),
                     kind: task::DebugAdapterKind::Fake,
@@ -296,7 +296,7 @@ async fn test_client_can_open_multiple_thread_panels(
         })
     });
 
-    let client = task.await.unwrap();
+    let (_session, client) = task.await.unwrap();
 
     client
         .on_request::<Initialize, _>(move |_, _| {
@@ -427,7 +427,7 @@ async fn test_handle_output_event(executor: BackgroundExecutor, cx: &mut TestApp
 
     let task = project.update(cx, |project, cx| {
         project.dap_store().update(cx, |store, cx| {
-            store.start_test_client(
+            store.start_test_debug_session(
                 task::DebugAdapterConfig {
                     label: "test config".into(),
                     kind: task::DebugAdapterKind::Fake,
@@ -441,7 +441,7 @@ async fn test_handle_output_event(executor: BackgroundExecutor, cx: &mut TestApp
         })
     });
 
-    let client = task.await.unwrap();
+    let (_session, client) = task.await.unwrap();
 
     client
         .on_request::<Initialize, _>(move |_, _| {

--- a/crates/debugger_ui/src/tests/debugger_panel.rs
+++ b/crates/debugger_ui/src/tests/debugger_panel.rs
@@ -17,7 +17,7 @@ async fn test_basic_show_debug_panel(executor: BackgroundExecutor, cx: &mut Test
 
     let task = project.update(cx, |project, cx| {
         project.dap_store().update(cx, |store, cx| {
-            store.start_test_debug_session(
+            store.start_debug_session(
                 task::DebugAdapterConfig {
                     label: "test config".into(),
                     kind: task::DebugAdapterKind::Fake,
@@ -134,7 +134,7 @@ async fn test_we_can_only_have_one_panel_per_debug_thread(
 
     let task = project.update(cx, |project, cx| {
         project.dap_store().update(cx, |store, cx| {
-            store.start_test_debug_session(
+            store.start_debug_session(
                 task::DebugAdapterConfig {
                     label: "test config".into(),
                     kind: task::DebugAdapterKind::Fake,
@@ -282,7 +282,7 @@ async fn test_client_can_open_multiple_thread_panels(
 
     let task = project.update(cx, |project, cx| {
         project.dap_store().update(cx, |store, cx| {
-            store.start_test_debug_session(
+            store.start_debug_session(
                 task::DebugAdapterConfig {
                     label: "test config".into(),
                     kind: task::DebugAdapterKind::Fake,
@@ -427,7 +427,7 @@ async fn test_handle_output_event(executor: BackgroundExecutor, cx: &mut TestApp
 
     let task = project.update(cx, |project, cx| {
         project.dap_store().update(cx, |store, cx| {
-            store.start_test_debug_session(
+            store.start_debug_session(
                 task::DebugAdapterConfig {
                     label: "test config".into(),
                     kind: task::DebugAdapterKind::Fake,

--- a/crates/debugger_ui/src/tests/stack_frame_list.rs
+++ b/crates/debugger_ui/src/tests/stack_frame_list.rs
@@ -51,7 +51,7 @@ async fn test_fetch_initial_stack_frames_and_go_to_stack_frame(
 
     let task = project.update(cx, |project, cx| {
         project.dap_store().update(cx, |store, cx| {
-            store.start_test_client(
+            store.start_test_debug_session(
                 task::DebugAdapterConfig {
                     label: "test config".into(),
                     kind: task::DebugAdapterKind::Fake,
@@ -65,7 +65,7 @@ async fn test_fetch_initial_stack_frames_and_go_to_stack_frame(
         })
     });
 
-    let client = task.await.unwrap();
+    let (_session, client) = task.await.unwrap();
 
     client
         .on_request::<Initialize, _>(move |_, _| {
@@ -215,7 +215,7 @@ async fn test_select_stack_frame(executor: BackgroundExecutor, cx: &mut TestAppC
 
     let task = project.update(cx, |project, cx| {
         project.dap_store().update(cx, |store, cx| {
-            store.start_test_client(
+            store.start_test_debug_session(
                 task::DebugAdapterConfig {
                     label: "test config".into(),
                     kind: task::DebugAdapterKind::Fake,
@@ -229,7 +229,7 @@ async fn test_select_stack_frame(executor: BackgroundExecutor, cx: &mut TestAppC
         })
     });
 
-    let client = task.await.unwrap();
+    let (_session, client) = task.await.unwrap();
 
     client
         .on_request::<Initialize, _>(move |_, _| {

--- a/crates/debugger_ui/src/tests/stack_frame_list.rs
+++ b/crates/debugger_ui/src/tests/stack_frame_list.rs
@@ -65,7 +65,7 @@ async fn test_fetch_initial_stack_frames_and_go_to_stack_frame(
         })
     });
 
-    let (_session, client) = task.await.unwrap();
+    let (session, client) = task.await.unwrap();
 
     client
         .on_request::<Initialize, _>(move |_, _| {
@@ -173,7 +173,7 @@ async fn test_fetch_initial_stack_frames_and_go_to_stack_frame(
 
     let shutdown_client = project.update(cx, |project, cx| {
         project.dap_store().update(cx, |dap_store, cx| {
-            dap_store.shutdown_client(&client.id(), cx)
+            dap_store.shutdown_session(&session.read(cx).id(), cx)
         })
     });
 
@@ -229,7 +229,7 @@ async fn test_select_stack_frame(executor: BackgroundExecutor, cx: &mut TestAppC
         })
     });
 
-    let (_session, client) = task.await.unwrap();
+    let (session, client) = task.await.unwrap();
 
     client
         .on_request::<Initialize, _>(move |_, _| {
@@ -420,7 +420,7 @@ async fn test_select_stack_frame(executor: BackgroundExecutor, cx: &mut TestAppC
 
     let shutdown_client = project.update(cx, |project, cx| {
         project.dap_store().update(cx, |dap_store, cx| {
-            dap_store.shutdown_client(&client.id(), cx)
+            dap_store.shutdown_session(&session.read(cx).id(), cx)
         })
     });
 

--- a/crates/debugger_ui/src/tests/stack_frame_list.rs
+++ b/crates/debugger_ui/src/tests/stack_frame_list.rs
@@ -51,7 +51,7 @@ async fn test_fetch_initial_stack_frames_and_go_to_stack_frame(
 
     let task = project.update(cx, |project, cx| {
         project.dap_store().update(cx, |store, cx| {
-            store.start_test_debug_session(
+            store.start_debug_session(
                 task::DebugAdapterConfig {
                     label: "test config".into(),
                     kind: task::DebugAdapterKind::Fake,
@@ -215,7 +215,7 @@ async fn test_select_stack_frame(executor: BackgroundExecutor, cx: &mut TestAppC
 
     let task = project.update(cx, |project, cx| {
         project.dap_store().update(cx, |store, cx| {
-            store.start_test_debug_session(
+            store.start_debug_session(
                 task::DebugAdapterConfig {
                     label: "test config".into(),
                     kind: task::DebugAdapterKind::Fake,

--- a/crates/debugger_ui/src/tests/variable_list.rs
+++ b/crates/debugger_ui/src/tests/variable_list.rs
@@ -47,7 +47,7 @@ async fn test_basic_fetch_initial_scope_and_variables(
 
     let task = project.update(cx, |project, cx| {
         project.dap_store().update(cx, |store, cx| {
-            store.start_test_client(
+            store.start_test_debug_session(
                 task::DebugAdapterConfig {
                     label: "test config".into(),
                     kind: task::DebugAdapterKind::Fake,
@@ -61,7 +61,7 @@ async fn test_basic_fetch_initial_scope_and_variables(
         })
     });
 
-    let client = task.await.unwrap();
+    let (_session, client) = task.await.unwrap();
 
     client
         .on_request::<Initialize, _>(move |_, _| {
@@ -297,7 +297,7 @@ async fn test_fetch_variables_for_multiple_scopes(
 
     let task = project.update(cx, |project, cx| {
         project.dap_store().update(cx, |store, cx| {
-            store.start_test_client(
+            store.start_test_debug_session(
                 task::DebugAdapterConfig {
                     label: "test config".into(),
                     kind: task::DebugAdapterKind::Fake,
@@ -311,7 +311,7 @@ async fn test_fetch_variables_for_multiple_scopes(
         })
     });
 
-    let client = task.await.unwrap();
+    let (_session, client) = task.await.unwrap();
 
     client
         .on_request::<Initialize, _>(move |_, _| {
@@ -594,7 +594,7 @@ async fn test_toggle_scope_and_variable(executor: BackgroundExecutor, cx: &mut T
 
     let task = project.update(cx, |project, cx| {
         project.dap_store().update(cx, |store, cx| {
-            store.start_test_client(
+            store.start_test_debug_session(
                 task::DebugAdapterConfig {
                     label: "test config".into(),
                     kind: task::DebugAdapterKind::Fake,
@@ -608,7 +608,7 @@ async fn test_toggle_scope_and_variable(executor: BackgroundExecutor, cx: &mut T
         })
     });
 
-    let client = task.await.unwrap();
+    let (_session, client) = task.await.unwrap();
 
     client
         .on_request::<Initialize, _>(move |_, _| {

--- a/crates/debugger_ui/src/tests/variable_list.rs
+++ b/crates/debugger_ui/src/tests/variable_list.rs
@@ -47,7 +47,7 @@ async fn test_basic_fetch_initial_scope_and_variables(
 
     let task = project.update(cx, |project, cx| {
         project.dap_store().update(cx, |store, cx| {
-            store.start_test_debug_session(
+            store.start_debug_session(
                 task::DebugAdapterConfig {
                     label: "test config".into(),
                     kind: task::DebugAdapterKind::Fake,
@@ -297,7 +297,7 @@ async fn test_fetch_variables_for_multiple_scopes(
 
     let task = project.update(cx, |project, cx| {
         project.dap_store().update(cx, |store, cx| {
-            store.start_test_debug_session(
+            store.start_debug_session(
                 task::DebugAdapterConfig {
                     label: "test config".into(),
                     kind: task::DebugAdapterKind::Fake,
@@ -594,7 +594,7 @@ async fn test_toggle_scope_and_variable(executor: BackgroundExecutor, cx: &mut T
 
     let task = project.update(cx, |project, cx| {
         project.dap_store().update(cx, |store, cx| {
-            store.start_test_debug_session(
+            store.start_debug_session(
                 task::DebugAdapterConfig {
                     label: "test config".into(),
                     kind: task::DebugAdapterKind::Fake,

--- a/crates/debugger_ui/src/tests/variable_list.rs
+++ b/crates/debugger_ui/src/tests/variable_list.rs
@@ -61,7 +61,7 @@ async fn test_basic_fetch_initial_scope_and_variables(
         })
     });
 
-    let (_session, client) = task.await.unwrap();
+    let (session, client) = task.await.unwrap();
 
     client
         .on_request::<Initialize, _>(move |_, _| {
@@ -254,7 +254,7 @@ async fn test_basic_fetch_initial_scope_and_variables(
 
     let shutdown_client = project.update(cx, |project, cx| {
         project.dap_store().update(cx, |dap_store, cx| {
-            dap_store.shutdown_client(&client.id(), cx)
+            dap_store.shutdown_session(&session.read(cx).id(), cx)
         })
     });
 
@@ -311,7 +311,7 @@ async fn test_fetch_variables_for_multiple_scopes(
         })
     });
 
-    let (_session, client) = task.await.unwrap();
+    let (session, client) = task.await.unwrap();
 
     client
         .on_request::<Initialize, _>(move |_, _| {
@@ -554,7 +554,7 @@ async fn test_fetch_variables_for_multiple_scopes(
 
     let shutdown_client = project.update(cx, |project, cx| {
         project.dap_store().update(cx, |dap_store, cx| {
-            dap_store.shutdown_client(&client.id(), cx)
+            dap_store.shutdown_session(&session.read(cx).id(), cx)
         })
     });
 
@@ -608,7 +608,7 @@ async fn test_toggle_scope_and_variable(executor: BackgroundExecutor, cx: &mut T
         })
     });
 
-    let (_session, client) = task.await.unwrap();
+    let (session, client) = task.await.unwrap();
 
     client
         .on_request::<Initialize, _>(move |_, _| {
@@ -1105,7 +1105,7 @@ async fn test_toggle_scope_and_variable(executor: BackgroundExecutor, cx: &mut T
 
     let shutdown_client = project.update(cx, |project, cx| {
         project.dap_store().update(cx, |dap_store, cx| {
-            dap_store.shutdown_client(&client.id(), cx)
+            dap_store.shutdown_session(&session.read(cx).id(), cx)
         })
     });
 

--- a/crates/debugger_ui/src/variable_list.rs
+++ b/crates/debugger_ui/src/variable_list.rs
@@ -831,7 +831,7 @@ impl VariableList {
     ) {
         let this = cx.view().clone();
 
-        let support_set_variable = self.dap_store.read_with(cx, |store, cx| {
+        let support_set_variable = self.dap_store.update(cx, |store, cx| {
             store
                 .capabilities_by_id(&self.client_id, cx)
                 .supports_set_variable

--- a/crates/debugger_ui/src/variable_list.rs
+++ b/crates/debugger_ui/src/variable_list.rs
@@ -831,12 +831,12 @@ impl VariableList {
     ) {
         let this = cx.view().clone();
 
-        let support_set_variable = self.dap_store.update(cx, |store, cx| {
-            store
-                .capabilities_by_id(&self.client_id, cx)
-                .supports_set_variable
-                .unwrap_or_default()
-        });
+        let support_set_variable = self
+            .dap_store
+            .read(cx)
+            .capabilities_by_id(&self.client_id)
+            .supports_set_variable
+            .unwrap_or_default();
 
         let context_menu = ContextMenu::build(cx, |menu, cx| {
             menu.entry(

--- a/crates/debugger_ui/src/variable_list.rs
+++ b/crates/debugger_ui/src/variable_list.rs
@@ -831,9 +831,9 @@ impl VariableList {
     ) {
         let this = cx.view().clone();
 
-        let support_set_variable = self.dap_store.read_with(cx, |store, _| {
+        let support_set_variable = self.dap_store.read_with(cx, |store, cx| {
             store
-                .capabilities_by_id(&self.client_id)
+                .capabilities_by_id(&self.client_id, cx)
                 .supports_set_variable
                 .unwrap_or_default()
         });

--- a/crates/project/src/dap_store.rs
+++ b/crates/project/src/dap_store.rs
@@ -1529,12 +1529,12 @@ impl DapStore {
         mut cx: AsyncAppContext,
     ) -> Result<()> {
         this.update(&mut cx, |dap_store, cx| {
-            if matches!(dap_store.mode, DapStoreMode::Remote(_)) {
-                let client_id = DebugAdapterClientId::from_proto(envelope.payload.client_id);
+            let client_id = DebugAdapterClientId::from_proto(envelope.payload.client_id);
 
-                cx.emit(DapStoreEvent::DebugClientShutdown(client_id));
-                cx.notify();
-            }
+            dap_store.capabilities.remove(&client_id);
+
+            cx.emit(DapStoreEvent::DebugClientShutdown(client_id));
+            cx.notify();
         })
     }
 
@@ -1552,7 +1552,7 @@ impl DapStore {
 
         this.update(&mut cx, |store, cx| {
             store.active_debug_line = Some((
-                DebugAdapterClientId(envelope.payload.client_id as usize),
+                DebugAdapterClientId::from_proto(envelope.payload.client_id),
                 project_path,
                 envelope.payload.row,
             ));

--- a/crates/project/src/dap_store.rs
+++ b/crates/project/src/dap_store.rs
@@ -931,9 +931,16 @@ impl DapStore {
                 });
 
                 match task {
-                    Ok(task) => match task.await.log_err() {
-                        Some(_) => (true, None),
-                        None => (false, None),
+                    Ok(task) => match task.await {
+                        Ok(_) => (true, None),
+                        Err(error) => {
+                            this.update(&mut cx, |_, cx| {
+                                cx.emit(DapStoreEvent::Notification(error.to_string()));
+                            })
+                            .log_err();
+
+                            (false, None)
+                        }
                     },
                     Err(_) => (false, None),
                 }

--- a/crates/project/src/dap_store.rs
+++ b/crates/project/src/dap_store.rs
@@ -225,7 +225,8 @@ impl DapStore {
     }
 
     pub fn session_by_id(&self, session_id: &DebugSessionId) -> Option<Model<DebugSession>> {
-        self.as_local().unwrap().sessions.get(session_id).cloned()
+        self.as_local()
+            .and_then(|store| store.sessions.get(session_id).cloned())
     }
 
     pub fn client_by_id(
@@ -233,9 +234,11 @@ impl DapStore {
         client_id: &DebugAdapterClientId,
         cx: &mut ModelContext<Self>,
     ) -> Option<(Model<DebugSession>, Arc<DebugAdapterClient>)> {
-        let session = self
-            .as_local()
-            .unwrap()
+        let Some(local_store) = self.as_local() else {
+            return None;
+        };
+
+        let session = local_store
             .sessions
             .get(self.client_by_session.get(client_id)?)
             .cloned()?;

--- a/crates/project/src/dap_store.rs
+++ b/crates/project/src/dap_store.rs
@@ -607,7 +607,17 @@ impl DapStore {
         cx.spawn(|this, mut cx| async move {
             let session = cx.new_model(|_| DebugSession::new(session_id, config))?;
 
-            let client = start_client_task.await?;
+            let client = match start_client_task.await {
+                Ok(client) => client,
+                Err(error) => {
+                    this.update(&mut cx, |_, cx| {
+                        cx.emit(DapStoreEvent::Notification(error.to_string()));
+                    })
+                    .log_err();
+
+                    return Err(error);
+                }
+            };
 
             this.update(&mut cx, |store, cx| {
                 session.update(cx, |session, cx| {

--- a/crates/project/src/dap_store.rs
+++ b/crates/project/src/dap_store.rs
@@ -71,11 +71,6 @@ pub enum DapStoreEvent {
     UpdateDebugAdapter(UpdateDebugAdapter),
 }
 
-pub enum DebugAdapterClientState {
-    Starting(Task<Option<Arc<DebugAdapterClient>>>),
-    Running(Arc<DebugAdapterClient>),
-}
-
 #[allow(clippy::large_enum_variant)]
 pub enum DapStoreMode {
     Local(LocalDapStore),   // ssh host and collab host

--- a/crates/project/src/dap_store.rs
+++ b/crates/project/src/dap_store.rs
@@ -258,7 +258,7 @@ impl DapStore {
             .unwrap_or_default()
     }
 
-    pub fn merge_capabilities_for_client(
+    pub fn update_capabilities_for_client(
         &mut self,
         session_id: &DebugSessionId,
         client_id: &DebugAdapterClientId,
@@ -668,7 +668,7 @@ impl DapStore {
                 .await?;
 
             this.update(&mut cx, |store, cx| {
-                store.merge_capabilities_for_client(&session_id, &client_id, &capabilities, cx);
+                store.update_capabilities_for_client(&session_id, &client_id, &capabilities, cx);
             })
         })
     }
@@ -1539,7 +1539,7 @@ impl DapStore {
         mut cx: AsyncAppContext,
     ) -> Result<()> {
         this.update(&mut cx, |dap_store, cx| {
-            dap_store.merge_capabilities_for_client(
+            dap_store.update_capabilities_for_client(
                 &DebugSessionId::from_proto(envelope.payload.session_id),
                 &DebugAdapterClientId::from_proto(envelope.payload.client_id),
                 &dap::proto_conversions::capabilities_from_proto(&envelope.payload),

--- a/crates/project/src/dap_store.rs
+++ b/crates/project/src/dap_store.rs
@@ -488,15 +488,6 @@ impl DapStore {
         })
     }
 
-    #[cfg(any(test, feature = "test-support"))]
-    pub fn start_test_debug_session(
-        &mut self,
-        config: DebugAdapterConfig,
-        cx: &mut ModelContext<Self>,
-    ) -> Task<Result<(Model<DebugSession>, Arc<DebugAdapterClient>)>> {
-        self.start_debug_session(config, cx)
-    }
-
     fn start_client_internal(
         &mut self,
         session_id: DebugSessionId,

--- a/crates/project/src/dap_store.rs
+++ b/crates/project/src/dap_store.rs
@@ -231,6 +231,10 @@ impl DapStore {
         })
     }
 
+    pub fn sessions(&self) -> impl Iterator<Item = Model<DebugSession>> + '_ {
+        self.sessions.values().cloned()
+    }
+
     pub fn session_by_id(&self, session_id: &DebugSessionId) -> Option<Model<DebugSession>> {
         self.sessions.get(session_id).cloned()
     }

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -34,6 +34,7 @@ use dap::{
     client::{DebugAdapterClient, DebugAdapterClientId},
     debugger_settings::DebuggerSettings,
     messages::Message,
+    session::DebugSessionId,
 };
 
 use collections::{BTreeSet, HashMap, HashSet};
@@ -251,11 +252,12 @@ pub enum Event {
     },
     LanguageServerPrompt(LanguageServerPromptRequest),
     LanguageNotFound(Model<Buffer>),
-    DebugClientStarted(DebugAdapterClientId),
-    DebugClientShutdown(DebugAdapterClientId),
+    DebugClientStarted((DebugSessionId, DebugAdapterClientId)),
+    DebugClientShutdown((DebugSessionId, DebugAdapterClientId)),
     SetDebugClient(SetDebuggerPanelItem),
     ActiveDebugLineChanged,
     DebugClientEvent {
+        session_id: DebugSessionId,
         client_id: DebugAdapterClientId,
         message: Message,
     },
@@ -2502,8 +2504,13 @@ impl Project {
             DapStoreEvent::DebugClientShutdown(client_id) => {
                 cx.emit(Event::DebugClientShutdown(*client_id));
             }
-            DapStoreEvent::DebugClientEvent { client_id, message } => {
+            DapStoreEvent::DebugClientEvent {
+                session_id,
+                client_id,
+                message,
+            } => {
                 cx.emit(Event::DebugClientEvent {
+                    session_id: *session_id,
                     client_id: *client_id,
                     message: message.clone(),
                 });

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -1272,9 +1272,9 @@ impl Project {
         debug_task: task::ResolvedTask,
         cx: &mut ModelContext<Self>,
     ) {
-        if let Some(adapter_config) = debug_task.debug_adapter_config() {
+        if let Some(config) = debug_task.debug_adapter_config() {
             self.dap_store.update(cx, |store, cx| {
-                store.start_client_from_debug_config(adapter_config, cx);
+                store.start_debug_session(config, cx).detach_and_log_err(cx);
             });
         }
     }
@@ -4598,14 +4598,6 @@ impl Project {
         cx: &'a AppContext,
     ) -> impl 'a + Iterator<Item = Arc<DebugAdapterClient>> {
         self.dap_store.read(cx).running_clients()
-    }
-
-    pub fn debug_client_for_id(
-        &self,
-        id: &DebugAdapterClientId,
-        cx: &AppContext,
-    ) -> Option<Arc<DebugAdapterClient>> {
-        self.dap_store.read(cx).client_by_id(id)
     }
 
     pub fn buffer_store(&self) -> &Model<BufferStore> {

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -1242,6 +1242,7 @@ impl Project {
 
     pub fn send_breakpoints(
         &self,
+        session_id: &DebugSessionId,
         client_id: &DebugAdapterClientId,
         cx: &mut ModelContext<Self>,
     ) -> Task<()> {
@@ -1258,7 +1259,7 @@ impl Project {
                     client_id,
                     abs_path,
                     source_breakpoints,
-                    store.ignore_breakpoints(client_id),
+                    store.ignore_breakpoints(session_id, cx),
                     cx,
                 )
             }));
@@ -1356,11 +1357,12 @@ impl Project {
 
     pub fn toggle_ignore_breakpoints(
         &self,
+        session_id: &DebugSessionId,
         client_id: &DebugAdapterClientId,
         cx: &mut ModelContext<Self>,
     ) -> Task<Result<()>> {
         let tasks = self.dap_store.update(cx, |store, cx| {
-            store.toggle_ignore_breakpoints(client_id);
+            store.toggle_ignore_breakpoints(session_id, cx);
 
             let mut tasks = Vec::new();
 
@@ -1389,7 +1391,7 @@ impl Project {
                             .into_iter()
                             .map(|breakpoint| breakpoint.to_source_breakpoint(buffer))
                             .collect::<Vec<_>>(),
-                        store.ignore_breakpoints(client_id),
+                        store.ignore_breakpoints(session_id, cx),
                         cx,
                     ),
                 );

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -4600,13 +4600,6 @@ impl Project {
             .language_servers_for_local_buffer(buffer, cx)
     }
 
-    pub fn debug_clients<'a>(
-        &'a self,
-        cx: &'a AppContext,
-    ) -> impl 'a + Iterator<Item = Arc<DebugAdapterClient>> {
-        self.dap_store.read(cx).running_clients()
-    }
-
     pub fn buffer_store(&self) -> &Model<BufferStore> {
         &self.buffer_store
     }

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -253,7 +253,7 @@ pub enum Event {
     LanguageServerPrompt(LanguageServerPromptRequest),
     LanguageNotFound(Model<Buffer>),
     DebugClientStarted((DebugSessionId, DebugAdapterClientId)),
-    DebugClientShutdown((DebugSessionId, DebugAdapterClientId)),
+    DebugClientShutdown(DebugAdapterClientId),
     SetDebugClient(SetDebuggerPanelItem),
     ActiveDebugLineChanged,
     DebugClientEvent {

--- a/crates/proto/proto/zed.proto
+++ b/crates/proto/proto/zed.proto
@@ -2606,14 +2606,14 @@ message SetDebuggerPanelItem {
     uint64 session_id = 2;
     uint64 client_id = 3;
     uint64 thread_id = 4;
-    DebuggerConsole console = 5;
-    DebuggerModuleList module_list = 6;
-    DebuggerThreadItem active_thread_item = 7;
-    DebuggerThreadState thread_state = 8;
-    DebuggerVariableList variable_list = 9;
-    DebuggerStackFrameList stack_frame_list = 10;
-    DebuggerLoadedSourceList loaded_source_list = 11;
-    string client_name = 12;
+    string session_name = 5;
+    DebuggerConsole console = 6;
+    DebuggerModuleList module_list = 7;
+    DebuggerThreadItem active_thread_item = 8;
+    DebuggerThreadState thread_state = 9;
+    DebuggerVariableList variable_list = 10;
+    DebuggerStackFrameList stack_frame_list = 11;
+    DebuggerLoadedSourceList loaded_source_list = 12;
 }
 
 message UpdateDebugAdapter {

--- a/crates/proto/proto/zed.proto
+++ b/crates/proto/proto/zed.proto
@@ -2420,21 +2420,23 @@ enum BreakpointKind {
 }
 
 message ShutdownDebugClient {
-    uint64 client_id = 1;
-    uint64 project_id = 2;
+    uint64 session_id = 1;
+    uint64 client_id = 2;
+    uint64 project_id = 3;
 }
 
 message SetDebugClientCapabilities {
-uint64 client_id = 1;
-uint64 project_id = 2;
-bool supports_loaded_sources_request = 3;
-bool supports_modules_request = 4;
-bool supports_restart_request = 5;
-bool supports_set_expression = 6;
-bool supports_single_thread_execution_requests = 7;
-bool supports_step_back = 8;
-bool supports_stepping_granularity = 9;
-bool supports_terminate_threads_request = 10;
+    uint64 session_id = 1;
+    uint64 client_id = 2;
+    uint64 project_id = 3;
+    bool supports_loaded_sources_request = 4;
+    bool supports_modules_request = 5;
+    bool supports_restart_request = 6;
+    bool supports_set_expression = 7;
+    bool supports_single_thread_execution_requests = 8;
+    bool supports_step_back = 9;
+    bool supports_stepping_granularity = 10;
+    bool supports_terminate_threads_request = 11;
 }
 
 message Breakpoint {
@@ -2601,16 +2603,17 @@ message DebuggerModuleList {
 
 message SetDebuggerPanelItem {
     uint64 project_id = 1;
-    uint64 client_id = 2;
-    uint64 thread_id = 3;
-    DebuggerConsole console = 4;
-    DebuggerModuleList module_list = 5;
-    DebuggerThreadItem active_thread_item = 6;
-    DebuggerThreadState thread_state = 7;
-    DebuggerVariableList variable_list = 8;
-    DebuggerStackFrameList stack_frame_list = 9;
-    DebuggerLoadedSourceList loaded_source_list = 10;
-    string client_name = 11;
+    uint64 session_id = 2;
+    uint64 client_id = 3;
+    uint64 thread_id = 4;
+    DebuggerConsole console = 5;
+    DebuggerModuleList module_list = 6;
+    DebuggerThreadItem active_thread_item = 7;
+    DebuggerThreadState thread_state = 8;
+    DebuggerVariableList variable_list = 9;
+    DebuggerStackFrameList stack_frame_list = 10;
+    DebuggerLoadedSourceList loaded_source_list = 11;
+    string client_name = 12;
 }
 
 message UpdateDebugAdapter {

--- a/crates/task/src/lib.rs
+++ b/crates/task/src/lib.rs
@@ -106,16 +106,12 @@ impl ResolvedTask {
         match self.original_task.task_type.clone() {
             TaskType::Script => None,
             TaskType::Debug(mut adapter_config) => {
-                let (cwd, program) = match &self.resolved {
-                    None => (adapter_config.cwd, adapter_config.program),
-                    Some(spawn_in_terminal) => (
-                        spawn_in_terminal.cwd.clone(),
-                        spawn_in_terminal.program.clone(),
-                    ),
-                };
+                if let Some(resolved) = &self.resolved {
+                    adapter_config.label = resolved.label.clone();
+                    adapter_config.program = resolved.program.clone().or(adapter_config.program);
+                    adapter_config.cwd = resolved.cwd.clone().or(adapter_config.cwd);
+                }
 
-                adapter_config.program = program;
-                adapter_config.cwd = cwd;
                 Some(adapter_config)
             }
         }


### PR DESCRIPTION
### Intro
This pr introduces a new layer called `DebugSession` the debug session is responsible for holding the clients, because we can have more clients for one debug session. Some debug adapter tell us to spawn a new client that should reconnect to the current already spawned debug adapter (first spawned client). This allows us also to show clients under a debug session inside the dap log, so it's more clear for users that we did not start 2 debug session, but we spawned 2 clients.

The reason behind this change is that a **user** had an issue with reverse request, not always both clients are shutting down. So instead of only shutting down the client that the adapter tells us to shut down, we also shut down the main client that spawned the adapter itself.

This PR also fixes a race issue with sending breakpoints and the configuration done request. See [bf293f9](https://github.com/RemcoSmitsDev/zed/pull/80/commits/bf293f91ee7a022e51a19d46754afbb7995eaab8).

---
### TODO's
- [x] Show debug sessions inside dap logs, with nested child clients
- [x] Make reverse requests work again
- [x] Rework shutdown client, so we also remove the session if there are no clients left anymore 
  - [x] Add tests to validate we can handle shutdown of multiple clients
- [x] Make collab capabilities work again
- [x] Move ignore breakpoints to debug session
- [x] Move sessions to local store
- [x] Style dap log menu, so session and clients are better visible

<img width="334" alt="Screenshot 2024-12-25 at 21 42 52" src="https://github.com/user-attachments/assets/07062238-e946-4da8-8167-168a3a0265da" />