### PR TITLE
Use Toast Notification for Debug Session Warning

### DIFF
--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -15,7 +15,7 @@ use dap::{
 };
 use gpui::{
     actions, Action, AppContext, AsyncWindowContext, EventEmitter, FocusHandle, FocusableView,
-    FontWeight, Model, Subscription, Task, View, ViewContext, WeakView,
+    Model, Subscription, Task, View, ViewContext, WeakView,
 };
 use project::{
     dap_store::{DapStore, DapStoreEvent},
@@ -117,7 +117,6 @@ pub struct DebugPanel {
     focus_handle: FocusHandle,
     dap_store: Model<DapStore>,
     workspace: WeakView<Workspace>,
-    show_did_not_stop_warning: bool,
     _subscriptions: Vec<Subscription>,
     message_queue: HashMap<DebugAdapterClientId, VecDeque<OutputEvent>>,
     thread_states: BTreeMap<(DebugAdapterClientId, u64), Model<ThreadState>>,
@@ -209,7 +208,6 @@ impl DebugPanel {
                 size: px(300.),
                 _subscriptions,
                 focus_handle: cx.focus_handle(),
-                show_did_not_stop_warning: false,
                 thread_states: Default::default(),
                 message_queue: Default::default(),
                 workspace: workspace.weak_handle(),
@@ -810,7 +808,12 @@ impl DebugPanel {
 
         if let Some(thread_state) = self.thread_states.get(&(*client_id, thread_id)) {
             if !thread_state.read(cx).stopped && event.reason == ThreadEventReason::Exited {
-                self.show_did_not_stop_warning = true;
+                const MESSAGE: &'static str = "Debug session exited without hitting breakpoints\n\nTry adding a breakpoint, or define the correct path mapping for your debugger.";
+
+                self.dap_store.update(cx, |_, cx| {
+                    cx.emit(DapStoreEvent::Notification(MESSAGE.into()));
+                });
+
                 cx.notify();
             };
         }
@@ -1034,48 +1037,6 @@ impl DebugPanel {
 
         cx.emit(DebugPanelEvent::CapabilitiesChanged(*client_id));
     }
-
-    fn render_did_not_stop_warning(&self, cx: &mut ViewContext<Self>) -> impl IntoElement {
-        const TITLE: &'static str = "Debug session exited without hitting any breakpoints";
-        const DESCRIPTION: &'static str =
-            "Try adding a breakpoint, or define the correct path mapping for your debugger.";
-
-        div()
-            .absolute()
-            .right_3()
-            .bottom_12()
-            .max_w_96()
-            .py_2()
-            .px_3()
-            .elevation_2(cx)
-            .occlude()
-            .child(
-                v_flex()
-                    .gap_0p5()
-                    .child(
-                        h_flex()
-                            .gap_1p5()
-                            .items_center()
-                            .child(Icon::new(IconName::Warning).color(Color::Conflict))
-                            .child(Label::new(TITLE).weight(FontWeight::MEDIUM)),
-                    )
-                    .child(
-                        Label::new(DESCRIPTION)
-                            .size(LabelSize::Small)
-                            .color(Color::Muted),
-                    )
-                    .child(
-                        h_flex().justify_end().mt_1().child(
-                            Button::new("dismiss", "Dismiss")
-                                .color(Color::Muted)
-                                .on_click(cx.listener(|this, _, cx| {
-                                    this.show_did_not_stop_warning = false;
-                                    cx.notify();
-                                })),
-                        ),
-                    ),
-            )
-    }
 }
 
 impl EventEmitter<PanelEvent> for DebugPanel {}
@@ -1146,9 +1107,6 @@ impl Render for DebugPanel {
             .key_context("DebugPanel")
             .track_focus(&self.focus_handle)
             .size_full()
-            .when(self.show_did_not_stop_warning, |this| {
-              this.child(self.render_did_not_stop_warning(cx))
-            })
             .map(|this| {
                 if self.pane.read(cx).items_len() == 0 {
                     this.child(

--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -813,8 +813,6 @@ impl DebugPanel {
                 self.dap_store.update(cx, |_, cx| {
                     cx.emit(DapStoreEvent::Notification(MESSAGE.into()));
                 });
-
-                cx.notify();
             };
         }
 
@@ -826,6 +824,7 @@ impl DebugPanel {
         }
 
         cx.emit(DebugPanelEvent::Thread((*client_id, event.clone())));
+        cx.notify();
     }
 
     fn handle_exited_event(


### PR DESCRIPTION
This switches the debug session exited without hitting breakpoints warning to a toast notification instead of a debug panel element. The advantage of using a toast notification is that a user will see it when the debug panel isn't open, which is common for this error because the debug panel opens when a breakpoint is hit.

@RemcoSmitsDev I wanted to get an OK on your end before merging this in because we talked about updating the toast notification to look better before merging this a couple of weeks ago. However, we've been really busy and haven't gotten to that yet, so I think it would be a good idea to merge this now, then update the toast notification when we have the time.

### Visual
<img width="1161" alt="Screenshot 2025-01-10 at 6 18 31 PM" src="https://github.com/user-attachments/assets/2823a1b3-1ea9-42d2-aaf8-5ff260e32b45" />



