### PR TITLE
Variable list keyboard navigation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3716,6 +3716,7 @@ dependencies = [
  "language",
  "menu",
  "picker",
+ "pretty_assertions",
  "project",
  "rpc",
  "serde",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -680,6 +680,14 @@
     }
   },
   {
+    "context": "VariableList",
+    "use_key_equivalents": true,
+    "bindings": {
+      "left": "variable_list::CollapseSelectedEntry",
+      "right": "variable_list::ExpandSelectedEntry"
+    }
+  },
+  {
     "context": "CollabPanel && not_editing",
     "use_key_equivalents": true,
     "bindings": {

--- a/crates/debugger_ui/Cargo.toml
+++ b/crates/debugger_ui/Cargo.toml
@@ -31,6 +31,7 @@ gpui.workspace = true
 language.workspace = true
 menu.workspace = true
 picker.workspace = true
+pretty_assertions.workspace = true
 project.workspace = true
 rpc.workspace = true
 serde.workspace = true
@@ -51,7 +52,6 @@ dap = { workspace = true, features = ["test-support"] }
 editor = { workspace = true, features = ["test-support"] }
 env_logger.workspace = true
 gpui = { workspace = true, features = ["test-support"] }
-pretty_assertions.workspace = true
 project = { workspace = true, features = ["test-support"] }
 unindent.workspace = true
 util = { workspace = true, features = ["test-support"] }

--- a/crates/debugger_ui/Cargo.toml
+++ b/crates/debugger_ui/Cargo.toml
@@ -51,7 +51,8 @@ dap = { workspace = true, features = ["test-support"] }
 editor = { workspace = true, features = ["test-support"] }
 env_logger.workspace = true
 gpui = { workspace = true, features = ["test-support"] }
+pretty_assertions.workspace = true
 project = { workspace = true, features = ["test-support"] }
-util = { workspace = true, features = ["test-support"] }
 unindent.workspace = true
+util = { workspace = true, features = ["test-support"] }
 workspace = { workspace = true, features = ["test-support"] }

--- a/crates/debugger_ui/src/debugger_panel_item.rs
+++ b/crates/debugger_ui/src/debugger_panel_item.rs
@@ -805,7 +805,7 @@ impl Render for DebugPanelItem {
 
         h_flex()
             .key_context("DebugPanelItem")
-            .track_focus(&self.focus_handle)
+            .track_focus(&self.focus_handle(cx))
             .size_full()
             .items_start()
             .child(

--- a/crates/debugger_ui/src/tests.rs
+++ b/crates/debugger_ui/src/tests.rs
@@ -1,10 +1,10 @@
-use gpui::{Model, TestAppContext, WindowHandle};
+use gpui::{Model, TestAppContext, View, WindowHandle};
 use project::Project;
 use settings::SettingsStore;
 use terminal_view::terminal_panel::TerminalPanel;
 use workspace::Workspace;
 
-use crate::debugger_panel::DebugPanel;
+use crate::{debugger_panel::DebugPanel, debugger_panel_item::DebugPanelItem};
 
 mod attach_modal;
 mod console;
@@ -56,4 +56,18 @@ pub async fn init_test_workspace(
         })
         .unwrap();
     window
+}
+
+pub fn active_debug_panel_item(
+    workspace: WindowHandle<Workspace>,
+    cx: &mut TestAppContext,
+) -> View<DebugPanelItem> {
+    workspace
+        .update(cx, |workspace, cx| {
+            let debug_panel = workspace.panel::<DebugPanel>(cx).unwrap();
+            debug_panel
+                .update(cx, |this, cx| this.active_debug_panel_item(cx))
+                .unwrap()
+        })
+        .unwrap()
 }

--- a/crates/debugger_ui/src/tests/console.rs
+++ b/crates/debugger_ui/src/tests/console.rs
@@ -10,7 +10,7 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc, Mutex,
 };
-use tests::{init_test, init_test_workspace};
+use tests::{active_debug_panel_item, init_test, init_test_workspace};
 use unindent::Unindent as _;
 use variable_list::{VariableContainer, VariableListEntry};
 
@@ -281,169 +281,140 @@ async fn test_evaluate_expression(executor: BackgroundExecutor, cx: &mut TestApp
     cx.run_until_parked();
 
     // toggle nested variables for scope 1
-    workspace
-        .update(cx, |workspace, cx| {
-            let debug_panel = workspace.panel::<DebugPanel>(cx).unwrap();
-            let active_debug_panel_item = debug_panel
-                .update(cx, |this, cx| this.active_debug_panel_item(cx))
-                .unwrap();
+    active_debug_panel_item(workspace, cx).update(cx, |debug_panel_item, cx| {
+        let scope1_variables = scope1_variables.lock().unwrap().clone();
 
-            active_debug_panel_item.update(cx, |debug_panel_item, cx| {
+        debug_panel_item
+            .variable_list()
+            .update(cx, |variable_list, cx| {
+                variable_list.toggle_entry(
+                    &variable_list::OpenEntry::Variable {
+                        scope_id: scopes[0].variables_reference,
+                        name: scope1_variables[0].name.clone(),
+                        depth: 1,
+                    },
+                    cx,
+                );
+            });
+    });
+
+    cx.run_until_parked();
+
+    active_debug_panel_item(workspace, cx).update(cx, |debug_panel_item, cx| {
+        debug_panel_item.console().update(cx, |console, cx| {
+            console.query_bar().update(cx, |query_bar, cx| {
+                query_bar.set_text(format!("$variable1 = {}", NEW_VALUE), cx);
+            });
+
+            console.evaluate(&menu::Confirm, cx);
+        });
+    });
+
+    cx.run_until_parked();
+
+    active_debug_panel_item(workspace, cx).update(cx, |debug_panel_item, cx| {
+        assert_eq!(
+            "",
+            debug_panel_item
+                .console()
+                .read(cx)
+                .query_bar()
+                .read(cx)
+                .text(cx)
+                .as_str()
+        );
+
+        assert_eq!(
+            format!("{}\n", NEW_VALUE),
+            debug_panel_item
+                .console()
+                .read(cx)
+                .editor()
+                .read(cx)
+                .text(cx)
+                .as_str()
+        );
+
+        debug_panel_item
+            .variable_list()
+            .update(cx, |variable_list, _| {
                 let scope1_variables = scope1_variables.lock().unwrap().clone();
 
-                debug_panel_item
-                    .variable_list()
-                    .update(cx, |variable_list, cx| {
-                        variable_list.toggle_entry(
-                            &variable_list::OpenEntry::Variable {
-                                scope_id: scopes[0].variables_reference,
-                                name: scope1_variables[0].name.clone(),
-                                depth: 1,
-                            },
-                            cx,
-                        );
-                    });
+                // scope 1
+                assert_eq!(
+                    vec![
+                        VariableContainer {
+                            container_reference: scopes[0].variables_reference,
+                            variable: scope1_variables[0].clone(),
+                            depth: 1,
+                        },
+                        VariableContainer {
+                            container_reference: scope1_variables[0].variables_reference,
+                            variable: nested_variables[0].clone(),
+                            depth: 2,
+                        },
+                        VariableContainer {
+                            container_reference: scope1_variables[0].variables_reference,
+                            variable: nested_variables[1].clone(),
+                            depth: 2,
+                        },
+                        VariableContainer {
+                            container_reference: scopes[0].variables_reference,
+                            variable: scope1_variables[1].clone(),
+                            depth: 1,
+                        },
+                    ],
+                    variable_list.variables_by_scope(1, 2).unwrap().variables()
+                );
+
+                // scope 2
+                assert_eq!(
+                    vec![VariableContainer {
+                        container_reference: scopes[1].variables_reference,
+                        variable: scope2_variables[0].clone(),
+                        depth: 1,
+                    }],
+                    variable_list.variables_by_scope(1, 4).unwrap().variables()
+                );
+
+                // assert visual entries
+                assert_eq!(
+                    vec![
+                        VariableListEntry::Scope(scopes[0].clone()),
+                        VariableListEntry::Variable {
+                            depth: 1,
+                            scope: Arc::new(scopes[0].clone()),
+                            has_children: true,
+                            variable: Arc::new(scope1_variables[0].clone()),
+                            container_reference: scopes[0].variables_reference,
+                        },
+                        VariableListEntry::Variable {
+                            depth: 2,
+                            scope: Arc::new(scopes[0].clone()),
+                            has_children: false,
+                            variable: Arc::new(nested_variables[0].clone()),
+                            container_reference: scope1_variables[0].variables_reference,
+                        },
+                        VariableListEntry::Variable {
+                            depth: 2,
+                            scope: Arc::new(scopes[0].clone()),
+                            has_children: false,
+                            variable: Arc::new(nested_variables[1].clone()),
+                            container_reference: scope1_variables[0].variables_reference,
+                        },
+                        VariableListEntry::Variable {
+                            depth: 1,
+                            scope: Arc::new(scopes[0].clone()),
+                            has_children: false,
+                            variable: Arc::new(scope1_variables[1].clone()),
+                            container_reference: scopes[0].variables_reference,
+                        },
+                        VariableListEntry::Scope(scopes[1].clone()),
+                    ],
+                    variable_list.entries().get(&1).unwrap().clone()
+                );
             });
-        })
-        .unwrap();
-
-    cx.run_until_parked();
-
-    workspace
-        .update(cx, |workspace, cx| {
-            let debug_panel = workspace.panel::<DebugPanel>(cx).unwrap();
-            let active_debug_panel_item = debug_panel
-                .update(cx, |this, cx| this.active_debug_panel_item(cx))
-                .unwrap();
-
-            active_debug_panel_item.update(cx, |item, cx| {
-                item.console().update(cx, |console, cx| {
-                    console.query_bar().update(cx, |query_bar, cx| {
-                        query_bar.set_text(format!("$variable1 = {}", NEW_VALUE), cx);
-                    });
-
-                    console.evaluate(&menu::Confirm, cx);
-                });
-            });
-        })
-        .unwrap();
-
-    cx.run_until_parked();
-
-    workspace
-        .update(cx, |workspace, cx| {
-            let debug_panel = workspace.panel::<DebugPanel>(cx).unwrap();
-            let active_debug_panel_item = debug_panel
-                .update(cx, |this, cx| this.active_debug_panel_item(cx))
-                .unwrap();
-
-            assert_eq!(
-                "",
-                active_debug_panel_item
-                    .read(cx)
-                    .console()
-                    .read(cx)
-                    .query_bar()
-                    .read(cx)
-                    .text(cx)
-                    .as_str()
-            );
-
-            assert_eq!(
-                format!("{}\n", NEW_VALUE),
-                active_debug_panel_item
-                    .read(cx)
-                    .console()
-                    .read(cx)
-                    .editor()
-                    .read(cx)
-                    .text(cx)
-                    .as_str()
-            );
-
-            active_debug_panel_item.update(cx, |debug_panel_item, cx| {
-                debug_panel_item
-                    .variable_list()
-                    .update(cx, |variable_list, _| {
-                        let scope1_variables = scope1_variables.lock().unwrap().clone();
-
-                        // scope 1
-                        assert_eq!(
-                            vec![
-                                VariableContainer {
-                                    container_reference: scopes[0].variables_reference,
-                                    variable: scope1_variables[0].clone(),
-                                    depth: 1,
-                                },
-                                VariableContainer {
-                                    container_reference: scope1_variables[0].variables_reference,
-                                    variable: nested_variables[0].clone(),
-                                    depth: 2,
-                                },
-                                VariableContainer {
-                                    container_reference: scope1_variables[0].variables_reference,
-                                    variable: nested_variables[1].clone(),
-                                    depth: 2,
-                                },
-                                VariableContainer {
-                                    container_reference: scopes[0].variables_reference,
-                                    variable: scope1_variables[1].clone(),
-                                    depth: 1,
-                                },
-                            ],
-                            variable_list.variables_by_scope(1, 2).unwrap().variables()
-                        );
-
-                        // scope 2
-                        assert_eq!(
-                            vec![VariableContainer {
-                                container_reference: scopes[1].variables_reference,
-                                variable: scope2_variables[0].clone(),
-                                depth: 1,
-                            }],
-                            variable_list.variables_by_scope(1, 4).unwrap().variables()
-                        );
-
-                        // assert visual entries
-                        assert_eq!(
-                            vec![
-                                VariableListEntry::Scope(scopes[0].clone()),
-                                VariableListEntry::Variable {
-                                    depth: 1,
-                                    scope: Arc::new(scopes[0].clone()),
-                                    has_children: true,
-                                    variable: Arc::new(scope1_variables[0].clone()),
-                                    container_reference: scopes[0].variables_reference,
-                                },
-                                VariableListEntry::Variable {
-                                    depth: 2,
-                                    scope: Arc::new(scopes[0].clone()),
-                                    has_children: false,
-                                    variable: Arc::new(nested_variables[0].clone()),
-                                    container_reference: scope1_variables[0].variables_reference,
-                                },
-                                VariableListEntry::Variable {
-                                    depth: 2,
-                                    scope: Arc::new(scopes[0].clone()),
-                                    has_children: false,
-                                    variable: Arc::new(nested_variables[1].clone()),
-                                    container_reference: scope1_variables[0].variables_reference,
-                                },
-                                VariableListEntry::Variable {
-                                    depth: 1,
-                                    scope: Arc::new(scopes[0].clone()),
-                                    has_children: false,
-                                    variable: Arc::new(scope1_variables[1].clone()),
-                                    container_reference: scopes[0].variables_reference,
-                                },
-                                VariableListEntry::Scope(scopes[1].clone()),
-                            ],
-                            variable_list.entries().get(&1).unwrap().clone()
-                        );
-                    });
-            });
-        })
-        .unwrap();
+    });
 
     assert!(
         called_evaluate.load(std::sync::atomic::Ordering::SeqCst),

--- a/crates/debugger_ui/src/tests/console.rs
+++ b/crates/debugger_ui/src/tests/console.rs
@@ -294,15 +294,12 @@ async fn test_evaluate_expression(executor: BackgroundExecutor, cx: &mut TestApp
                 debug_panel_item
                     .variable_list()
                     .update(cx, |variable_list, cx| {
-                        variable_list.on_toggle_variable(
-                            scopes[0].variables_reference, // scope id
-                            &crate::variable_list::OpenEntry::Variable {
+                        variable_list.toggle_entry(
+                            &variable_list::OpenEntry::Variable {
+                                scope_id: scopes[0].variables_reference,
                                 name: scope1_variables[0].name.clone(),
                                 depth: 1,
                             },
-                            scope1_variables[0].variables_reference,
-                            1, // depth
-                            Some(false),
                             cx,
                         );
                     });

--- a/crates/debugger_ui/src/tests/debugger_panel.rs
+++ b/crates/debugger_ui/src/tests/debugger_panel.rs
@@ -741,7 +741,7 @@ async fn test_handle_error_run_in_terminal_reverse_request(
                 send_response.store(true, Ordering::SeqCst);
 
                 assert!(!response.success);
-                assert!(response.body.is_none());
+                assert!(response.body.is_some());
             }
         })
         .await;

--- a/crates/debugger_ui/src/tests/variable_list.rs
+++ b/crates/debugger_ui/src/tests/variable_list.rs
@@ -227,7 +227,6 @@ async fn test_basic_fetch_initial_scope_and_variables(
                             variable_list.variables(cx)
                         );
 
-                        // assert visual entries
                         variable_list.assert_visual_entries(
                             vec!["v Scope 1", "    > variable1", "    > variable2"],
                             cx,
@@ -504,7 +503,6 @@ async fn test_fetch_variables_for_multiple_scopes(
                             variable_list.variables_by_scope(1, 3).unwrap().variables()
                         );
 
-                        // assert visual entries
                         variable_list.assert_visual_entries(
                             vec![
                                 "v Scope 1",
@@ -803,7 +801,6 @@ async fn test_toggle_scope_and_variable(executor: BackgroundExecutor, cx: &mut T
                             variable_list.variables_by_scope(1, 4).unwrap().variables()
                         );
 
-                        // assert visual entries
                         variable_list.assert_visual_entries(
                             vec![
                                 "v Scope 1",
@@ -893,7 +890,6 @@ async fn test_toggle_scope_and_variable(executor: BackgroundExecutor, cx: &mut T
                             variable_list.variables_by_scope(1, 4).unwrap().variables()
                         );
 
-                        // assert visual entries
                         variable_list.assert_visual_entries(
                             vec![
                                 "v Scope 1",
@@ -983,7 +979,6 @@ async fn test_toggle_scope_and_variable(executor: BackgroundExecutor, cx: &mut T
                             variable_list.variables_by_scope(1, 4).unwrap().variables()
                         );
 
-                        // assert visual entries
                         variable_list.assert_visual_entries(
                             vec![
                                 "v Scope 1",
@@ -1076,7 +1071,6 @@ async fn test_toggle_scope_and_variable(executor: BackgroundExecutor, cx: &mut T
                             variable_list.variables_by_scope(1, 4).unwrap().variables()
                         );
 
-                        // assert visual entries
                         variable_list.assert_visual_entries(
                             vec![
                                 "v Scope 1",
@@ -1348,7 +1342,6 @@ async fn test_keyboard_navigation(executor: BackgroundExecutor, cx: &mut TestApp
         debug_panel_item
             .variable_list()
             .update(cx, |variable_list, cx| {
-                // assert visual entries
                 variable_list.assert_visual_entries(
                     vec![
                         "v Scope 1 <=== selected",
@@ -1368,7 +1361,6 @@ async fn test_keyboard_navigation(executor: BackgroundExecutor, cx: &mut TestApp
         debug_panel_item
             .variable_list()
             .update(cx, |variable_list, cx| {
-                // assert visual entries
                 variable_list.assert_visual_entries(
                     vec![
                         "v Scope 1",
@@ -1388,7 +1380,6 @@ async fn test_keyboard_navigation(executor: BackgroundExecutor, cx: &mut TestApp
         debug_panel_item
             .variable_list()
             .update(cx, |variable_list, cx| {
-                // assert visual entries
                 variable_list.assert_visual_entries(
                     vec![
                         "v Scope 1",
@@ -1410,7 +1401,6 @@ async fn test_keyboard_navigation(executor: BackgroundExecutor, cx: &mut TestApp
         debug_panel_item
             .variable_list()
             .update(cx, |variable_list, cx| {
-                // assert visual entries
                 variable_list.assert_visual_entries(
                     vec![
                         "v Scope 1",
@@ -1432,7 +1422,6 @@ async fn test_keyboard_navigation(executor: BackgroundExecutor, cx: &mut TestApp
         debug_panel_item
             .variable_list()
             .update(cx, |variable_list, cx| {
-                // assert visual entries
                 variable_list.assert_visual_entries(
                     vec![
                         "v Scope 1",
@@ -1454,7 +1443,6 @@ async fn test_keyboard_navigation(executor: BackgroundExecutor, cx: &mut TestApp
         debug_panel_item
             .variable_list()
             .update(cx, |variable_list, cx| {
-                // assert visual entries
                 variable_list.assert_visual_entries(
                     vec![
                         "v Scope 1",
@@ -1476,7 +1464,6 @@ async fn test_keyboard_navigation(executor: BackgroundExecutor, cx: &mut TestApp
         debug_panel_item
             .variable_list()
             .update(cx, |variable_list, cx| {
-                // assert visual entries
                 variable_list.assert_visual_entries(
                     vec![
                         "v Scope 1",
@@ -1498,7 +1485,6 @@ async fn test_keyboard_navigation(executor: BackgroundExecutor, cx: &mut TestApp
         debug_panel_item
             .variable_list()
             .update(cx, |variable_list, cx| {
-                // assert visual entries
                 variable_list.assert_visual_entries(
                     vec![
                         "v Scope 1",
@@ -1521,7 +1507,6 @@ async fn test_keyboard_navigation(executor: BackgroundExecutor, cx: &mut TestApp
         debug_panel_item
             .variable_list()
             .update(cx, |variable_list, cx| {
-                // assert visual entries
                 variable_list.assert_visual_entries(
                     vec![
                         "v Scope 1",
@@ -1544,7 +1529,6 @@ async fn test_keyboard_navigation(executor: BackgroundExecutor, cx: &mut TestApp
         debug_panel_item
             .variable_list()
             .update(cx, |variable_list, cx| {
-                // assert visual entries
                 variable_list.assert_visual_entries(
                     vec![
                         "v Scope 1",
@@ -1567,7 +1551,6 @@ async fn test_keyboard_navigation(executor: BackgroundExecutor, cx: &mut TestApp
         debug_panel_item
             .variable_list()
             .update(cx, |variable_list, cx| {
-                // assert visual entries
                 variable_list.assert_visual_entries(
                     vec![
                         "v Scope 1",
@@ -1589,7 +1572,6 @@ async fn test_keyboard_navigation(executor: BackgroundExecutor, cx: &mut TestApp
         debug_panel_item
             .variable_list()
             .update(cx, |variable_list, cx| {
-                // assert visual entries
                 variable_list.assert_visual_entries(
                     vec![
                         "v Scope 1",
@@ -1611,7 +1593,6 @@ async fn test_keyboard_navigation(executor: BackgroundExecutor, cx: &mut TestApp
         debug_panel_item
             .variable_list()
             .update(cx, |variable_list, cx| {
-                // assert visual entries
                 variable_list.assert_visual_entries(
                     vec![
                         "v Scope 1",
@@ -1633,7 +1614,6 @@ async fn test_keyboard_navigation(executor: BackgroundExecutor, cx: &mut TestApp
         debug_panel_item
             .variable_list()
             .update(cx, |variable_list, cx| {
-                // assert visual entries
                 variable_list.assert_visual_entries(
                     vec![
                         "v Scope 1",
@@ -1655,7 +1635,6 @@ async fn test_keyboard_navigation(executor: BackgroundExecutor, cx: &mut TestApp
         debug_panel_item
             .variable_list()
             .update(cx, |variable_list, cx| {
-                // assert visual entries
                 variable_list.assert_visual_entries(
                     vec![
                         "v Scope 1",
@@ -1677,7 +1656,6 @@ async fn test_keyboard_navigation(executor: BackgroundExecutor, cx: &mut TestApp
         debug_panel_item
             .variable_list()
             .update(cx, |variable_list, cx| {
-                // assert visual entries
                 variable_list.assert_visual_entries(
                     vec![
                         "v Scope 1",
@@ -1697,7 +1675,6 @@ async fn test_keyboard_navigation(executor: BackgroundExecutor, cx: &mut TestApp
         debug_panel_item
             .variable_list()
             .update(cx, |variable_list, cx| {
-                // assert visual entries
                 variable_list.assert_visual_entries(
                     vec![
                         "v Scope 1 <=== selected",
@@ -1717,7 +1694,6 @@ async fn test_keyboard_navigation(executor: BackgroundExecutor, cx: &mut TestApp
         debug_panel_item
             .variable_list()
             .update(cx, |variable_list, cx| {
-                // assert visual entries
                 variable_list
                     .assert_visual_entries(vec!["> Scope 1 <=== selected", "> Scope 2"], cx);
             });

--- a/crates/debugger_ui/src/tests/variable_list.rs
+++ b/crates/debugger_ui/src/tests/variable_list.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use crate::{
     debugger_panel::DebugPanel,
     tests::{init_test, init_test_workspace},
-    variable_list::{VariableContainer, VariableListEntry},
+    variable_list::{self, VariableContainer},
 };
 use collections::HashMap;
 use dap::{
@@ -829,15 +829,12 @@ async fn test_toggle_scope_and_variable(executor: BackgroundExecutor, cx: &mut T
                 debug_panel_item
                     .variable_list()
                     .update(cx, |variable_list, cx| {
-                        variable_list.on_toggle_variable(
-                            scopes[0].variables_reference, // scope id
-                            &crate::variable_list::OpenEntry::Variable {
+                        variable_list.toggle_entry(
+                            &variable_list::OpenEntry::Variable {
+                                scope_id: scopes[0].variables_reference,
                                 name: scope1_variables[0].name.clone(),
                                 depth: 1,
                             },
-                            scope1_variables[0].variables_reference,
-                            1, // depth
-                            Some(false),
                             cx,
                         );
                     });
@@ -1019,6 +1016,7 @@ async fn test_toggle_scope_and_variable(executor: BackgroundExecutor, cx: &mut T
                             &crate::variable_list::OpenEntry::Variable {
                                 name: scope1_variables[0].name.clone(),
                                 depth: 1,
+                                scope_id: scopes[0].variables_reference,
                             },
                             cx,
                         );

--- a/crates/debugger_ui/src/tests/variable_list.rs
+++ b/crates/debugger_ui/src/tests/variable_list.rs
@@ -1,9 +1,8 @@
 use std::sync::Arc;
 
 use crate::{
-    debugger_panel::DebugPanel,
     tests::{active_debug_panel_item, init_test, init_test_workspace},
-    variable_list::{self, CollapseSelectedEntry, ExpandSelectedEntry, VariableContainer},
+    variable_list::{CollapseSelectedEntry, ExpandSelectedEntry, VariableContainer},
 };
 use collections::HashMap;
 use dap::{
@@ -193,48 +192,39 @@ async fn test_basic_fetch_initial_scope_and_variables(
 
     cx.run_until_parked();
 
-    workspace
-        .update(cx, |workspace, cx| {
-            let debug_panel = workspace.panel::<DebugPanel>(cx).unwrap();
-            let active_debug_panel_item = debug_panel
-                .update(cx, |this, cx| this.active_debug_panel_item(cx))
-                .unwrap();
+    active_debug_panel_item(workspace, cx).update(cx, |debug_panel_item, cx| {
+        let stack_frame_list = debug_panel_item.stack_frame_list().read(cx);
 
-            active_debug_panel_item.update(cx, |debug_panel_item, cx| {
-                let stack_frame_list = debug_panel_item.stack_frame_list().read(cx);
+        assert_eq!(1, stack_frame_list.current_stack_frame_id());
+        assert_eq!(stack_frames, stack_frame_list.stack_frames().clone());
 
-                assert_eq!(1, stack_frame_list.current_stack_frame_id());
-                assert_eq!(stack_frames, stack_frame_list.stack_frames().clone());
+        debug_panel_item
+            .variable_list()
+            .update(cx, |variable_list, cx| {
+                assert_eq!(1, variable_list.scopes().len());
+                assert_eq!(scopes, variable_list.scopes().get(&1).unwrap().clone());
+                assert_eq!(
+                    vec![
+                        VariableContainer {
+                            container_reference: scopes[0].variables_reference,
+                            variable: variables[0].clone(),
+                            depth: 1,
+                        },
+                        VariableContainer {
+                            container_reference: scopes[0].variables_reference,
+                            variable: variables[1].clone(),
+                            depth: 1,
+                        },
+                    ],
+                    variable_list.variables(cx)
+                );
 
-                debug_panel_item
-                    .variable_list()
-                    .update(cx, |variable_list, cx| {
-                        assert_eq!(1, variable_list.scopes().len());
-                        assert_eq!(scopes, variable_list.scopes().get(&1).unwrap().clone());
-                        assert_eq!(
-                            vec![
-                                VariableContainer {
-                                    container_reference: scopes[0].variables_reference,
-                                    variable: variables[0].clone(),
-                                    depth: 1,
-                                },
-                                VariableContainer {
-                                    container_reference: scopes[0].variables_reference,
-                                    variable: variables[1].clone(),
-                                    depth: 1,
-                                },
-                            ],
-                            variable_list.variables(cx)
-                        );
-
-                        variable_list.assert_visual_entries(
-                            vec!["v Scope 1", "    > variable1", "    > variable2"],
-                            cx,
-                        );
-                    });
+                variable_list.assert_visual_entries(
+                    vec!["v Scope 1", "    > variable1", "    > variable2"],
+                    cx,
+                );
             });
-        })
-        .unwrap();
+    });
 
     let shutdown_session = project.update(cx, |project, cx| {
         project.dap_store().update(cx, |dap_store, cx| {
@@ -457,65 +447,56 @@ async fn test_fetch_variables_for_multiple_scopes(
 
     cx.run_until_parked();
 
-    workspace
-        .update(cx, |workspace, cx| {
-            let debug_panel = workspace.panel::<DebugPanel>(cx).unwrap();
-            let active_debug_panel_item = debug_panel
-                .update(cx, |this, cx| this.active_debug_panel_item(cx))
-                .unwrap();
+    active_debug_panel_item(workspace, cx).update(cx, |debug_panel_item, cx| {
+        let stack_frame_list = debug_panel_item.stack_frame_list().read(cx);
 
-            active_debug_panel_item.update(cx, |debug_panel_item, cx| {
-                let stack_frame_list = debug_panel_item.stack_frame_list().read(cx);
+        assert_eq!(1, stack_frame_list.current_stack_frame_id());
+        assert_eq!(stack_frames, stack_frame_list.stack_frames().clone());
 
-                assert_eq!(1, stack_frame_list.current_stack_frame_id());
-                assert_eq!(stack_frames, stack_frame_list.stack_frames().clone());
+        debug_panel_item
+            .variable_list()
+            .update(cx, |variable_list, cx| {
+                assert_eq!(1, variable_list.scopes().len());
+                assert_eq!(scopes, variable_list.scopes().get(&1).unwrap().clone());
 
-                debug_panel_item
-                    .variable_list()
-                    .update(cx, |variable_list, cx| {
-                        assert_eq!(1, variable_list.scopes().len());
-                        assert_eq!(scopes, variable_list.scopes().get(&1).unwrap().clone());
+                // scope 1
+                assert_eq!(
+                    vec![
+                        VariableContainer {
+                            container_reference: scopes[0].variables_reference,
+                            variable: variables.get(&2).unwrap()[0].clone(),
+                            depth: 1,
+                        },
+                        VariableContainer {
+                            container_reference: scopes[0].variables_reference,
+                            variable: variables.get(&2).unwrap()[1].clone(),
+                            depth: 1,
+                        },
+                    ],
+                    variable_list.variables_by_scope(1, 2).unwrap().variables()
+                );
 
-                        // scope 1
-                        assert_eq!(
-                            vec![
-                                VariableContainer {
-                                    container_reference: scopes[0].variables_reference,
-                                    variable: variables.get(&2).unwrap()[0].clone(),
-                                    depth: 1,
-                                },
-                                VariableContainer {
-                                    container_reference: scopes[0].variables_reference,
-                                    variable: variables.get(&2).unwrap()[1].clone(),
-                                    depth: 1,
-                                },
-                            ],
-                            variable_list.variables_by_scope(1, 2).unwrap().variables()
-                        );
+                // scope 2
+                assert_eq!(
+                    vec![VariableContainer {
+                        container_reference: scopes[1].variables_reference,
+                        variable: variables.get(&3).unwrap()[0].clone(),
+                        depth: 1,
+                    }],
+                    variable_list.variables_by_scope(1, 3).unwrap().variables()
+                );
 
-                        // scope 2
-                        assert_eq!(
-                            vec![VariableContainer {
-                                container_reference: scopes[1].variables_reference,
-                                variable: variables.get(&3).unwrap()[0].clone(),
-                                depth: 1,
-                            }],
-                            variable_list.variables_by_scope(1, 3).unwrap().variables()
-                        );
-
-                        variable_list.assert_visual_entries(
-                            vec![
-                                "v Scope 1",
-                                "    > variable1",
-                                "    > variable2",
-                                "> Scope 2",
-                            ],
-                            cx,
-                        );
-                    });
+                variable_list.assert_visual_entries(
+                    vec![
+                        "v Scope 1",
+                        "    > variable1",
+                        "    > variable2",
+                        "> Scope 2",
+                    ],
+                    cx,
+                );
             });
-        })
-        .unwrap();
+    });
 
     let shutdown_session = project.update(cx, |project, cx| {
         project.dap_store().update(cx, |dap_store, cx| {
@@ -527,574 +508,6 @@ async fn test_fetch_variables_for_multiple_scopes(
 }
 
 // tests that toggling a variable will fetch its children and shows it
-#[gpui::test]
-async fn test_toggle_scope_and_variable(executor: BackgroundExecutor, cx: &mut TestAppContext) {
-    init_test(cx);
-
-    let fs = FakeFs::new(executor.clone());
-
-    let test_file_content = r#"
-        const variable1 = {
-            nested1: "Nested 1",
-            nested2: "Nested 2",
-        };
-        const variable2 = "Value 2";
-        const variable3 = "Value 3";
-    "#
-    .unindent();
-
-    fs.insert_tree(
-        "/project",
-        json!({
-           "src": {
-               "test.js": test_file_content,
-           }
-        }),
-    )
-    .await;
-
-    let project = Project::test(fs, ["/project".as_ref()], cx).await;
-    let workspace = init_test_workspace(&project, cx).await;
-    let cx = &mut VisualTestContext::from_window(*workspace, cx);
-
-    let task = project.update(cx, |project, cx| {
-        project.dap_store().update(cx, |store, cx| {
-            store.start_debug_session(
-                task::DebugAdapterConfig {
-                    label: "test config".into(),
-                    kind: task::DebugAdapterKind::Fake,
-                    request: task::DebugRequestType::Launch,
-                    program: None,
-                    cwd: None,
-                    initialize_args: None,
-                },
-                cx,
-            )
-        })
-    });
-
-    let (session, client) = task.await.unwrap();
-
-    client
-        .on_request::<Initialize, _>(move |_, _| {
-            Ok(dap::Capabilities {
-                supports_step_back: Some(false),
-                ..Default::default()
-            })
-        })
-        .await;
-
-    client.on_request::<Launch, _>(move |_, _| Ok(())).await;
-
-    let stack_frames = vec![StackFrame {
-        id: 1,
-        name: "Stack Frame 1".into(),
-        source: Some(dap::Source {
-            name: Some("test.js".into()),
-            path: Some("/project/src/test.js".into()),
-            source_reference: None,
-            presentation_hint: None,
-            origin: None,
-            sources: None,
-            adapter_data: None,
-            checksums: None,
-        }),
-        line: 1,
-        column: 1,
-        end_line: None,
-        end_column: None,
-        can_restart: None,
-        instruction_pointer_reference: None,
-        module_id: None,
-        presentation_hint: None,
-    }];
-
-    client
-        .on_request::<StackTrace, _>({
-            let stack_frames = Arc::new(stack_frames.clone());
-            move |_, args| {
-                assert_eq!(1, args.thread_id);
-
-                Ok(dap::StackTraceResponse {
-                    stack_frames: (*stack_frames).clone(),
-                    total_frames: None,
-                })
-            }
-        })
-        .await;
-
-    let scopes = vec![
-        Scope {
-            name: "Scope 1".into(),
-            presentation_hint: None,
-            variables_reference: 2,
-            named_variables: None,
-            indexed_variables: None,
-            expensive: false,
-            source: None,
-            line: None,
-            column: None,
-            end_line: None,
-            end_column: None,
-        },
-        Scope {
-            name: "Scope 2".into(),
-            presentation_hint: None,
-            variables_reference: 4,
-            named_variables: None,
-            indexed_variables: None,
-            expensive: false,
-            source: None,
-            line: None,
-            column: None,
-            end_line: None,
-            end_column: None,
-        },
-    ];
-
-    client
-        .on_request::<Scopes, _>({
-            let scopes = Arc::new(scopes.clone());
-            move |_, args| {
-                assert_eq!(1, args.frame_id);
-
-                Ok(dap::ScopesResponse {
-                    scopes: (*scopes).clone(),
-                })
-            }
-        })
-        .await;
-
-    let scope1_variables = vec![
-        Variable {
-            name: "variable1".into(),
-            value: "{nested1: \"Nested 1\", nested2: \"Nested 2\"}".into(),
-            type_: None,
-            presentation_hint: None,
-            evaluate_name: None,
-            variables_reference: 3,
-            named_variables: None,
-            indexed_variables: None,
-            memory_reference: None,
-        },
-        Variable {
-            name: "variable2".into(),
-            value: "Value 2".into(),
-            type_: None,
-            presentation_hint: None,
-            evaluate_name: None,
-            variables_reference: 0,
-            named_variables: None,
-            indexed_variables: None,
-            memory_reference: None,
-        },
-    ];
-
-    let nested_variables = vec![
-        Variable {
-            name: "nested1".into(),
-            value: "Nested 1".into(),
-            type_: None,
-            presentation_hint: None,
-            evaluate_name: None,
-            variables_reference: 0,
-            named_variables: None,
-            indexed_variables: None,
-            memory_reference: None,
-        },
-        Variable {
-            name: "nested2".into(),
-            value: "Nested 2".into(),
-            type_: None,
-            presentation_hint: None,
-            evaluate_name: None,
-            variables_reference: 0,
-            named_variables: None,
-            indexed_variables: None,
-            memory_reference: None,
-        },
-    ];
-
-    let scope2_variables = vec![Variable {
-        name: "variable3".into(),
-        value: "Value 3".into(),
-        type_: None,
-        presentation_hint: None,
-        evaluate_name: None,
-        variables_reference: 0,
-        named_variables: None,
-        indexed_variables: None,
-        memory_reference: None,
-    }];
-
-    client
-        .on_request::<Variables, _>({
-            let scope1_variables = Arc::new(scope1_variables.clone());
-            let nested_variables = Arc::new(nested_variables.clone());
-            let scope2_variables = Arc::new(scope2_variables.clone());
-            move |_, args| match args.variables_reference {
-                4 => Ok(dap::VariablesResponse {
-                    variables: (*scope2_variables).clone(),
-                }),
-                3 => Ok(dap::VariablesResponse {
-                    variables: (*nested_variables).clone(),
-                }),
-                2 => Ok(dap::VariablesResponse {
-                    variables: (*scope1_variables).clone(),
-                }),
-                id => unreachable!("unexpected variables reference {id}"),
-            }
-        })
-        .await;
-
-    client.on_request::<Disconnect, _>(move |_, _| Ok(())).await;
-
-    client
-        .fake_event(dap::messages::Events::Stopped(dap::StoppedEvent {
-            reason: dap::StoppedEventReason::Pause,
-            description: None,
-            thread_id: Some(1),
-            preserve_focus_hint: None,
-            text: None,
-            all_threads_stopped: None,
-            hit_breakpoint_ids: None,
-        }))
-        .await;
-
-    cx.run_until_parked();
-
-    workspace
-        .update(cx, |workspace, cx| {
-            let debug_panel = workspace.panel::<DebugPanel>(cx).unwrap();
-            let active_debug_panel_item = debug_panel
-                .update(cx, |this, cx| this.active_debug_panel_item(cx))
-                .unwrap();
-
-            active_debug_panel_item.update(cx, |debug_panel_item, cx| {
-                debug_panel_item
-                    .variable_list()
-                    .update(cx, |variable_list, cx| {
-                        // scope 1
-                        assert_eq!(
-                            vec![
-                                VariableContainer {
-                                    container_reference: scopes[0].variables_reference,
-                                    variable: scope1_variables[0].clone(),
-                                    depth: 1,
-                                },
-                                VariableContainer {
-                                    container_reference: scopes[0].variables_reference,
-                                    variable: scope1_variables[1].clone(),
-                                    depth: 1,
-                                },
-                            ],
-                            variable_list.variables_by_scope(1, 2).unwrap().variables()
-                        );
-
-                        // scope 2
-                        assert_eq!(
-                            vec![VariableContainer {
-                                container_reference: scopes[1].variables_reference,
-                                variable: scope2_variables[0].clone(),
-                                depth: 1,
-                            }],
-                            variable_list.variables_by_scope(1, 4).unwrap().variables()
-                        );
-
-                        variable_list.assert_visual_entries(
-                            vec![
-                                "v Scope 1",
-                                "    > variable1",
-                                "    > variable2",
-                                "> Scope 2",
-                            ],
-                            cx,
-                        );
-                    });
-            });
-        })
-        .unwrap();
-
-    // toggle nested variables for scope 1
-    workspace
-        .update(cx, |workspace, cx| {
-            let debug_panel = workspace.panel::<DebugPanel>(cx).unwrap();
-            let active_debug_panel_item = debug_panel
-                .update(cx, |this, cx| this.active_debug_panel_item(cx))
-                .unwrap();
-
-            active_debug_panel_item.update(cx, |debug_panel_item, cx| {
-                debug_panel_item
-                    .variable_list()
-                    .update(cx, |variable_list, cx| {
-                        variable_list.toggle_entry(
-                            &variable_list::OpenEntry::Variable {
-                                scope_id: scopes[0].variables_reference,
-                                name: scope1_variables[0].name.clone(),
-                                depth: 1,
-                            },
-                            cx,
-                        );
-                    });
-            });
-        })
-        .unwrap();
-
-    cx.run_until_parked();
-
-    workspace
-        .update(cx, |workspace, cx| {
-            let debug_panel = workspace.panel::<DebugPanel>(cx).unwrap();
-            let active_debug_panel_item = debug_panel
-                .update(cx, |this, cx| this.active_debug_panel_item(cx))
-                .unwrap();
-
-            active_debug_panel_item.update(cx, |debug_panel_item, cx| {
-                debug_panel_item
-                    .variable_list()
-                    .update(cx, |variable_list, cx| {
-                        // scope 1
-                        assert_eq!(
-                            vec![
-                                VariableContainer {
-                                    container_reference: scopes[0].variables_reference,
-                                    variable: scope1_variables[0].clone(),
-                                    depth: 1,
-                                },
-                                VariableContainer {
-                                    container_reference: scope1_variables[0].variables_reference,
-                                    variable: nested_variables[0].clone(),
-                                    depth: 2,
-                                },
-                                VariableContainer {
-                                    container_reference: scope1_variables[0].variables_reference,
-                                    variable: nested_variables[1].clone(),
-                                    depth: 2,
-                                },
-                                VariableContainer {
-                                    container_reference: scopes[0].variables_reference,
-                                    variable: scope1_variables[1].clone(),
-                                    depth: 1,
-                                },
-                            ],
-                            variable_list.variables_by_scope(1, 2).unwrap().variables()
-                        );
-
-                        // scope 2
-                        assert_eq!(
-                            vec![VariableContainer {
-                                container_reference: scopes[1].variables_reference,
-                                variable: scope2_variables[0].clone(),
-                                depth: 1,
-                            }],
-                            variable_list.variables_by_scope(1, 4).unwrap().variables()
-                        );
-
-                        variable_list.assert_visual_entries(
-                            vec![
-                                "v Scope 1",
-                                "    v variable1",
-                                "        > nested1",
-                                "        > nested2",
-                                "    > variable2",
-                                "> Scope 2",
-                            ],
-                            cx,
-                        );
-                    });
-            });
-        })
-        .unwrap();
-
-    // toggle scope 2 to show variables
-    workspace
-        .update(cx, |workspace, cx| {
-            let debug_panel = workspace.panel::<DebugPanel>(cx).unwrap();
-            let active_debug_panel_item = debug_panel
-                .update(cx, |this, cx| this.active_debug_panel_item(cx))
-                .unwrap();
-
-            active_debug_panel_item.update(cx, |debug_panel_item, cx| {
-                debug_panel_item
-                    .variable_list()
-                    .update(cx, |variable_list, cx| {
-                        variable_list.toggle_entry(
-                            &crate::variable_list::OpenEntry::Scope {
-                                name: scopes[1].name.clone(),
-                            },
-                            cx,
-                        );
-                    });
-            });
-        })
-        .unwrap();
-
-    cx.run_until_parked();
-
-    workspace
-        .update(cx, |workspace, cx| {
-            let debug_panel = workspace.panel::<DebugPanel>(cx).unwrap();
-            let active_debug_panel_item = debug_panel
-                .update(cx, |this, cx| this.active_debug_panel_item(cx))
-                .unwrap();
-
-            active_debug_panel_item.update(cx, |debug_panel_item, cx| {
-                debug_panel_item
-                    .variable_list()
-                    .update(cx, |variable_list, cx| {
-                        // scope 1
-                        assert_eq!(
-                            vec![
-                                VariableContainer {
-                                    container_reference: scopes[0].variables_reference,
-                                    variable: scope1_variables[0].clone(),
-                                    depth: 1,
-                                },
-                                VariableContainer {
-                                    container_reference: scope1_variables[0].variables_reference,
-                                    variable: nested_variables[0].clone(),
-                                    depth: 2,
-                                },
-                                VariableContainer {
-                                    container_reference: scope1_variables[0].variables_reference,
-                                    variable: nested_variables[1].clone(),
-                                    depth: 2,
-                                },
-                                VariableContainer {
-                                    container_reference: scopes[0].variables_reference,
-                                    variable: scope1_variables[1].clone(),
-                                    depth: 1,
-                                },
-                            ],
-                            variable_list.variables_by_scope(1, 2).unwrap().variables()
-                        );
-
-                        // scope 2
-                        assert_eq!(
-                            vec![VariableContainer {
-                                container_reference: scopes[1].variables_reference,
-                                variable: scope2_variables[0].clone(),
-                                depth: 1,
-                            }],
-                            variable_list.variables_by_scope(1, 4).unwrap().variables()
-                        );
-
-                        variable_list.assert_visual_entries(
-                            vec![
-                                "v Scope 1",
-                                "    v variable1",
-                                "        > nested1",
-                                "        > nested2",
-                                "    > variable2",
-                                "v Scope 2",
-                                "    > variable3",
-                            ],
-                            cx,
-                        );
-                    });
-            });
-        })
-        .unwrap();
-
-    // toggle variable that has child variables to hide variables
-    workspace
-        .update(cx, |workspace, cx| {
-            let debug_panel = workspace.panel::<DebugPanel>(cx).unwrap();
-            let active_debug_panel_item = debug_panel
-                .update(cx, |this, cx| this.active_debug_panel_item(cx))
-                .unwrap();
-
-            active_debug_panel_item.update(cx, |debug_panel_item, cx| {
-                debug_panel_item
-                    .variable_list()
-                    .update(cx, |variable_list, cx| {
-                        variable_list.toggle_entry(
-                            &crate::variable_list::OpenEntry::Variable {
-                                name: scope1_variables[0].name.clone(),
-                                depth: 1,
-                                scope_id: scopes[0].variables_reference,
-                            },
-                            cx,
-                        );
-                    });
-            });
-        })
-        .unwrap();
-
-    cx.run_until_parked();
-
-    workspace
-        .update(cx, |workspace, cx| {
-            let debug_panel = workspace.panel::<DebugPanel>(cx).unwrap();
-            let active_debug_panel_item = debug_panel
-                .update(cx, |this, cx| this.active_debug_panel_item(cx))
-                .unwrap();
-
-            active_debug_panel_item.update(cx, |debug_panel_item, cx| {
-                debug_panel_item
-                    .variable_list()
-                    .update(cx, |variable_list, cx| {
-                        // scope 1
-                        assert_eq!(
-                            vec![
-                                VariableContainer {
-                                    container_reference: scopes[0].variables_reference,
-                                    variable: scope1_variables[0].clone(),
-                                    depth: 1,
-                                },
-                                VariableContainer {
-                                    container_reference: scope1_variables[0].variables_reference,
-                                    variable: nested_variables[0].clone(),
-                                    depth: 2,
-                                },
-                                VariableContainer {
-                                    container_reference: scope1_variables[0].variables_reference,
-                                    variable: nested_variables[1].clone(),
-                                    depth: 2,
-                                },
-                                VariableContainer {
-                                    container_reference: scopes[0].variables_reference,
-                                    variable: scope1_variables[1].clone(),
-                                    depth: 1,
-                                },
-                            ],
-                            variable_list.variables_by_scope(1, 2).unwrap().variables()
-                        );
-
-                        // scope 2
-                        assert_eq!(
-                            vec![VariableContainer {
-                                container_reference: scopes[1].variables_reference,
-                                variable: scope2_variables[0].clone(),
-                                depth: 1,
-                            }],
-                            variable_list.variables_by_scope(1, 4).unwrap().variables()
-                        );
-
-                        variable_list.assert_visual_entries(
-                            vec![
-                                "v Scope 1",
-                                "    > variable1",
-                                "    > variable2",
-                                "v Scope 2",
-                                "    > variable3",
-                            ],
-                            cx,
-                        );
-                    });
-            });
-        })
-        .unwrap();
-
-    let shutdown_session = project.update(cx, |project, cx| {
-        project.dap_store().update(cx, |dap_store, cx| {
-            dap_store.shutdown_session(&session.read(cx).id(), cx)
-        })
-    });
-
-    shutdown_session.await.unwrap();
-}
-
 #[gpui::test]
 async fn test_keyboard_navigation(executor: BackgroundExecutor, cx: &mut TestAppContext) {
     init_test(cx);

--- a/crates/debugger_ui/src/tests/variable_list.rs
+++ b/crates/debugger_ui/src/tests/variable_list.rs
@@ -227,25 +227,9 @@ async fn test_basic_fetch_initial_scope_and_variables(
                         );
 
                         // assert visual entries
-                        assert_eq!(
-                            vec![
-                                VariableListEntry::Scope(scopes[0].clone()),
-                                VariableListEntry::Variable {
-                                    depth: 1,
-                                    scope: Arc::new(scopes[0].clone()),
-                                    has_children: false,
-                                    variable: Arc::new(variables[0].clone()),
-                                    container_reference: scopes[0].variables_reference,
-                                },
-                                VariableListEntry::Variable {
-                                    depth: 1,
-                                    scope: Arc::new(scopes[0].clone()),
-                                    has_children: false,
-                                    variable: Arc::new(variables[1].clone()),
-                                    container_reference: scopes[0].variables_reference,
-                                },
-                            ],
-                            variable_list.entries().get(&1).unwrap().clone()
+                        variable_list.assert_visual_entries(
+                            vec!["v Scope 1", "    > variable1", "    > variable2"],
+                            cx,
                         );
                     });
             });
@@ -488,7 +472,7 @@ async fn test_fetch_variables_for_multiple_scopes(
 
                 debug_panel_item
                     .variable_list()
-                    .update(cx, |variable_list, _| {
+                    .update(cx, |variable_list, cx| {
                         assert_eq!(1, variable_list.scopes().len());
                         assert_eq!(scopes, variable_list.scopes().get(&1).unwrap().clone());
 
@@ -520,32 +504,14 @@ async fn test_fetch_variables_for_multiple_scopes(
                         );
 
                         // assert visual entries
-                        assert_eq!(
+                        variable_list.assert_visual_entries(
                             vec![
-                                VariableListEntry::Scope(scopes[0].clone()),
-                                VariableListEntry::Variable {
-                                    depth: 1,
-                                    scope: Arc::new(scopes[0].clone()),
-                                    has_children: false,
-                                    variable: Arc::new(
-                                        variables.get(&scopes[0].variables_reference).unwrap()[0]
-                                            .clone()
-                                    ),
-                                    container_reference: scopes[0].variables_reference,
-                                },
-                                VariableListEntry::Variable {
-                                    depth: 1,
-                                    scope: Arc::new(scopes[0].clone()),
-                                    has_children: false,
-                                    variable: Arc::new(
-                                        variables.get(&scopes[0].variables_reference).unwrap()[1]
-                                            .clone()
-                                    ),
-                                    container_reference: scopes[0].variables_reference,
-                                },
-                                VariableListEntry::Scope(scopes[1].clone()),
+                                "v Scope 1",
+                                "    > variable1",
+                                "    > variable2",
+                                "> Scope 2",
                             ],
-                            variable_list.entries().get(&1).unwrap().clone()
+                            cx,
                         );
                     });
             });
@@ -808,7 +774,7 @@ async fn test_toggle_scope_and_variable(executor: BackgroundExecutor, cx: &mut T
             active_debug_panel_item.update(cx, |debug_panel_item, cx| {
                 debug_panel_item
                     .variable_list()
-                    .update(cx, |variable_list, _| {
+                    .update(cx, |variable_list, cx| {
                         // scope 1
                         assert_eq!(
                             vec![
@@ -837,26 +803,14 @@ async fn test_toggle_scope_and_variable(executor: BackgroundExecutor, cx: &mut T
                         );
 
                         // assert visual entries
-                        assert_eq!(
+                        variable_list.assert_visual_entries(
                             vec![
-                                VariableListEntry::Scope(scopes[0].clone()),
-                                VariableListEntry::Variable {
-                                    depth: 1,
-                                    scope: Arc::new(scopes[0].clone()),
-                                    has_children: true,
-                                    variable: Arc::new(scope1_variables[0].clone()),
-                                    container_reference: scopes[0].variables_reference,
-                                },
-                                VariableListEntry::Variable {
-                                    depth: 1,
-                                    scope: Arc::new(scopes[0].clone()),
-                                    has_children: false,
-                                    variable: Arc::new(scope1_variables[1].clone()),
-                                    container_reference: scopes[0].variables_reference,
-                                },
-                                VariableListEntry::Scope(scopes[1].clone()),
+                                "v Scope 1",
+                                "    > variable1",
+                                "    > variable2",
+                                "> Scope 2",
                             ],
-                            variable_list.entries().get(&1).unwrap().clone()
+                            cx,
                         );
                     });
             });
@@ -903,7 +857,7 @@ async fn test_toggle_scope_and_variable(executor: BackgroundExecutor, cx: &mut T
             active_debug_panel_item.update(cx, |debug_panel_item, cx| {
                 debug_panel_item
                     .variable_list()
-                    .update(cx, |variable_list, _| {
+                    .update(cx, |variable_list, cx| {
                         // scope 1
                         assert_eq!(
                             vec![
@@ -942,40 +896,16 @@ async fn test_toggle_scope_and_variable(executor: BackgroundExecutor, cx: &mut T
                         );
 
                         // assert visual entries
-                        assert_eq!(
+                        variable_list.assert_visual_entries(
                             vec![
-                                VariableListEntry::Scope(scopes[0].clone()),
-                                VariableListEntry::Variable {
-                                    depth: 1,
-                                    scope: Arc::new(scopes[0].clone()),
-                                    has_children: true,
-                                    variable: Arc::new(scope1_variables[0].clone()),
-                                    container_reference: scopes[0].variables_reference,
-                                },
-                                VariableListEntry::Variable {
-                                    depth: 2,
-                                    scope: Arc::new(scopes[0].clone()),
-                                    has_children: false,
-                                    variable: Arc::new(nested_variables[0].clone()),
-                                    container_reference: scope1_variables[0].variables_reference,
-                                },
-                                VariableListEntry::Variable {
-                                    depth: 2,
-                                    scope: Arc::new(scopes[0].clone()),
-                                    has_children: false,
-                                    variable: Arc::new(nested_variables[1].clone()),
-                                    container_reference: scope1_variables[0].variables_reference,
-                                },
-                                VariableListEntry::Variable {
-                                    depth: 1,
-                                    scope: Arc::new(scopes[0].clone()),
-                                    has_children: false,
-                                    variable: Arc::new(scope1_variables[1].clone()),
-                                    container_reference: scopes[0].variables_reference,
-                                },
-                                VariableListEntry::Scope(scopes[1].clone()),
+                                "v Scope 1",
+                                "    v variable1",
+                                "        > nested1",
+                                "        > nested2",
+                                "    > variable2",
+                                "> Scope 2",
                             ],
-                            variable_list.entries().get(&1).unwrap().clone()
+                            cx,
                         );
                     });
             });
@@ -1017,7 +947,7 @@ async fn test_toggle_scope_and_variable(executor: BackgroundExecutor, cx: &mut T
             active_debug_panel_item.update(cx, |debug_panel_item, cx| {
                 debug_panel_item
                     .variable_list()
-                    .update(cx, |variable_list, _| {
+                    .update(cx, |variable_list, cx| {
                         // scope 1
                         assert_eq!(
                             vec![
@@ -1056,47 +986,17 @@ async fn test_toggle_scope_and_variable(executor: BackgroundExecutor, cx: &mut T
                         );
 
                         // assert visual entries
-                        assert_eq!(
+                        variable_list.assert_visual_entries(
                             vec![
-                                VariableListEntry::Scope(scopes[0].clone()),
-                                VariableListEntry::Variable {
-                                    depth: 1,
-                                    scope: Arc::new(scopes[0].clone()),
-                                    has_children: true,
-                                    variable: Arc::new(scope1_variables[0].clone()),
-                                    container_reference: scopes[0].variables_reference,
-                                },
-                                VariableListEntry::Variable {
-                                    depth: 2,
-                                    scope: Arc::new(scopes[0].clone()),
-                                    has_children: false,
-                                    variable: Arc::new(nested_variables[0].clone()),
-                                    container_reference: scope1_variables[0].variables_reference,
-                                },
-                                VariableListEntry::Variable {
-                                    depth: 2,
-                                    scope: Arc::new(scopes[0].clone()),
-                                    has_children: false,
-                                    variable: Arc::new(nested_variables[1].clone()),
-                                    container_reference: scope1_variables[0].variables_reference,
-                                },
-                                VariableListEntry::Variable {
-                                    depth: 1,
-                                    scope: Arc::new(scopes[0].clone()),
-                                    has_children: false,
-                                    variable: Arc::new(scope1_variables[1].clone()),
-                                    container_reference: scopes[0].variables_reference,
-                                },
-                                VariableListEntry::Scope(scopes[1].clone()),
-                                VariableListEntry::Variable {
-                                    depth: 1,
-                                    scope: Arc::new(scopes[1].clone()),
-                                    has_children: false,
-                                    variable: Arc::new(scope2_variables[0].clone()),
-                                    container_reference: scopes[1].variables_reference,
-                                },
+                                "v Scope 1",
+                                "    v variable1",
+                                "        > nested1",
+                                "        > nested2",
+                                "    > variable2",
+                                "v Scope 2",
+                                "    > variable3",
                             ],
-                            variable_list.entries().get(&1).unwrap().clone()
+                            cx,
                         );
                     });
             });
@@ -1139,7 +1039,7 @@ async fn test_toggle_scope_and_variable(executor: BackgroundExecutor, cx: &mut T
             active_debug_panel_item.update(cx, |debug_panel_item, cx| {
                 debug_panel_item
                     .variable_list()
-                    .update(cx, |variable_list, _| {
+                    .update(cx, |variable_list, cx| {
                         // scope 1
                         assert_eq!(
                             vec![
@@ -1178,33 +1078,15 @@ async fn test_toggle_scope_and_variable(executor: BackgroundExecutor, cx: &mut T
                         );
 
                         // assert visual entries
-                        assert_eq!(
+                        variable_list.assert_visual_entries(
                             vec![
-                                VariableListEntry::Scope(scopes[0].clone()),
-                                VariableListEntry::Variable {
-                                    depth: 1,
-                                    scope: Arc::new(scopes[0].clone()),
-                                    has_children: true,
-                                    variable: Arc::new(scope1_variables[0].clone()),
-                                    container_reference: scopes[0].variables_reference,
-                                },
-                                VariableListEntry::Variable {
-                                    depth: 1,
-                                    scope: Arc::new(scopes[0].clone()),
-                                    has_children: false,
-                                    variable: Arc::new(scope1_variables[1].clone()),
-                                    container_reference: scopes[0].variables_reference,
-                                },
-                                VariableListEntry::Scope(scopes[1].clone()),
-                                VariableListEntry::Variable {
-                                    depth: 1,
-                                    scope: Arc::new(scopes[1].clone()),
-                                    has_children: false,
-                                    variable: Arc::new(scope2_variables[0].clone()),
-                                    container_reference: scopes[1].variables_reference,
-                                },
+                                "v Scope 1",
+                                "    > variable1",
+                                "    > variable2",
+                                "v Scope 2",
+                                "    > variable3",
                             ],
-                            variable_list.entries().get(&1).unwrap().clone()
+                            cx,
                         );
                     });
             });

--- a/crates/debugger_ui/src/variable_list.rs
+++ b/crates/debugger_ui/src/variable_list.rs
@@ -1372,7 +1372,7 @@ impl VariableList {
             };
         }
 
-        assert_eq!(expected, visual_entries);
+        pretty_assertions::assert_eq!(expected, visual_entries);
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/crates/debugger_ui/src/variable_list.rs
+++ b/crates/debugger_ui/src/variable_list.rs
@@ -608,7 +608,6 @@ impl VariableList {
         };
 
         let entry = &entries[ix];
-
         match entry {
             VariableListEntry::Scope(scope) => {
                 self.render_scope(scope, Some(entry) == self.selection.as_ref(), cx)
@@ -1363,8 +1362,8 @@ impl VariableList {
     fn render_variable(
         &self,
         container_reference: u64,
-        variable: &Variable,
-        scope: &Scope,
+        variable: &Arc<Variable>,
+        scope: &Arc<Scope>,
         depth: usize,
         has_children: bool,
         is_selected: bool,
@@ -1402,6 +1401,20 @@ impl VariableList {
             .h_4()
             .size_full()
             .hover(|style| style.bg(bg_hover_color))
+            .on_click(cx.listener({
+                let scope = scope.clone();
+                let variable = variable.clone();
+                move |this, _, cx| {
+                    this.selection = Some(VariableListEntry::Variable {
+                        depth,
+                        has_children,
+                        container_reference,
+                        scope: scope.clone(),
+                        variable: variable.clone(),
+                    });
+                    cx.notify();
+                }
+            }))
             .child(
                 ListItem::new(SharedString::from(format!(
                     "variable-item-{}-{}-{}",
@@ -1482,6 +1495,13 @@ impl VariableList {
             .w_full()
             .h_full()
             .hover(|style| style.bg(bg_hover_color))
+            .on_click(cx.listener({
+                let scope = scope.clone();
+                move |this, _, cx| {
+                    this.selection = Some(VariableListEntry::Scope(scope.clone()));
+                    cx.notify();
+                }
+            }))
             .child(
                 ListItem::new(SharedString::from(format!(
                     "scope-{}",

--- a/crates/debugger_ui/src/variable_list.rs
+++ b/crates/debugger_ui/src/variable_list.rs
@@ -148,7 +148,7 @@ impl OpenEntry {
             proto::variable_list_open_entry::Entry::Variable(state) => Some(Self::Variable {
                 name: state.name.clone(),
                 depth: state.depth as usize,
-                scope_id: state.scope_id as u64,
+                scope_id: state.scope_id,
             }),
         }
     }
@@ -665,7 +665,7 @@ impl VariableList {
             store.variables(&self.client_id, variable.variables_reference, cx)
         });
 
-        let container_reference = variable.variables_reference.clone();
+        let container_reference = variable.variables_reference;
         let entry_id = entry_id.clone();
 
         self.fetch_variables_task = Some(cx.spawn(|this, mut cx| async move {

--- a/crates/debugger_ui/src/variable_list.rs
+++ b/crates/debugger_ui/src/variable_list.rs
@@ -7,7 +7,8 @@ use dap::{
 use editor::{actions::SelectAll, Editor, EditorEvent};
 use gpui::{
     actions, anchored, deferred, list, AnyElement, ClipboardItem, DismissEvent, FocusHandle,
-    FocusableView, ListOffset, ListState, Model, MouseDownEvent, Point, Subscription, Task, View,
+    FocusableView, Hsla, ListOffset, ListState, Model, MouseDownEvent, Point, Subscription, Task,
+    View,
 };
 use menu::{Confirm, SelectFirst, SelectNext, SelectPrev};
 use project::dap_store::DapStore;
@@ -1377,18 +1378,16 @@ impl VariableList {
         };
         let disclosed = has_children.then(|| self.open_entries.binary_search(&entry_id).is_ok());
 
-        let colors = cx.theme().colors();
-
+        let colors = get_entry_color(cx);
         let bg_hover_color = if !is_selected {
-            colors.ghost_element_hover
+            colors.hover
         } else {
-            colors.panel_background
+            colors.default
         };
-
         let border_color = if is_selected {
-            colors.ghost_element_selected
+            colors.marked_active
         } else {
-            colors.panel_background
+            colors.default
         };
 
         div()
@@ -1461,18 +1460,16 @@ impl VariableList {
         };
         let disclosed = self.open_entries.binary_search(&entry_id).is_ok();
 
-        let colors = cx.theme().colors();
-
+        let colors = get_entry_color(cx);
         let bg_hover_color = if !is_selected {
-            colors.ghost_element_hover
+            colors.hover
         } else {
-            colors.panel_background
+            colors.default
         };
-
         let border_color = if is_selected {
-            colors.ghost_element_selected
+            colors.marked_active
         } else {
-            colors.panel_background
+            colors.default
         };
 
         div()
@@ -1533,6 +1530,22 @@ impl Render for VariableList {
                 )
                 .with_priority(1)
             }))
+    }
+}
+
+struct EntryColors {
+    default: Hsla,
+    hover: Hsla,
+    marked_active: Hsla,
+}
+
+fn get_entry_color(cx: &ViewContext<VariableList>) -> EntryColors {
+    let colors = cx.theme().colors();
+
+    EntryColors {
+        default: colors.panel_background,
+        hover: colors.ghost_element_hover,
+        marked_active: colors.ghost_element_selected,
     }
 }
 

--- a/crates/debugger_ui/src/variable_list.rs
+++ b/crates/debugger_ui/src/variable_list.rs
@@ -10,7 +10,7 @@ use gpui::{
     FocusableView, Hsla, ListOffset, ListState, Model, MouseDownEvent, Point, Subscription, Task,
     View,
 };
-use menu::{Confirm, SelectFirst, SelectNext, SelectPrev};
+use menu::{Confirm, SelectFirst, SelectLast, SelectNext, SelectPrev};
 use project::dap_store::DapStore;
 use proto::debugger_variable_list_entry::Entry;
 use rpc::proto::{
@@ -1167,6 +1167,14 @@ impl VariableList {
         };
     }
 
+    fn select_last(&mut self, _: &SelectLast, cx: &mut ViewContext<Self>) {
+        let stack_frame_id = self.stack_frame_list.read(cx).current_stack_frame_id();
+        if let Some(entries) = self.entries.get(&stack_frame_id) {
+            self.selection = entries.last().cloned();
+            cx.notify();
+        };
+    }
+
     fn select_prev(&mut self, _: &SelectPrev, cx: &mut ViewContext<Self>) {
         if let Some(selection) = &self.selection {
             let stack_frame_id = self.stack_frame_list.read(cx).current_stack_frame_id();
@@ -1550,6 +1558,8 @@ impl Render for VariableList {
             .group("variable-list")
             .size_full()
             .track_focus(&self.focus_handle(cx))
+            .on_action(cx.listener(Self::select_first))
+            .on_action(cx.listener(Self::select_last))
             .on_action(cx.listener(Self::select_prev))
             .on_action(cx.listener(Self::select_next))
             .on_action(cx.listener(Self::expand_selected_entry))

--- a/crates/debugger_ui/src/variable_list.rs
+++ b/crates/debugger_ui/src/variable_list.rs
@@ -1298,59 +1298,6 @@ impl VariableList {
             .into_any_element()
     }
 
-    // #[allow(clippy::too_many_arguments)]
-    // pub fn on_toggle_variable(
-    //     &mut self,
-    //     scope_id: u64,
-    //     entry_id: &OpenEntry,
-    //     variable_reference: u64,
-    //     depth: usize,
-    //     disclosed: Option<bool>,
-    //     cx: &mut ViewContext<Self>,
-    // ) {
-    //     let stack_frame_id = self.stack_frame_list.read(cx).current_stack_frame_id();
-
-    //     let Some(index) = self.variables_by_scope(stack_frame_id, scope_id) else {
-    //         return;
-    //     };
-
-    //     // if we already opened the variable/we already fetched it
-    //     // we can just toggle it because we already have the nested variable
-    //     if disclosed.unwrap_or(true) || index.fetched(&variable_reference) {
-    //         return self.toggle_entry(&entry_id, cx);
-    //     }
-
-    //     let fetch_variables_task = self.dap_store.update(cx, |store, cx| {
-    //         store.variables(&self.client_id, variable_reference, cx)
-    //     });
-
-    //     let entry_id = entry_id.clone();
-    //     cx.spawn(|this, mut cx| async move {
-    //         let new_variables = fetch_variables_task.await?;
-
-    //         this.update(&mut cx, |this, cx| {
-    //             let Some(index) = this.variables.get_mut(&(stack_frame_id, scope_id)) else {
-    //                 return;
-    //             };
-
-    //             index.add_variables(
-    //                 variable_reference,
-    //                 new_variables
-    //                     .into_iter()
-    //                     .map(|variable| VariableContainer {
-    //                         container_reference: variable_reference,
-    //                         variable,
-    //                         depth: depth + 1,
-    //                     })
-    //                     .collect::<Vec<_>>(),
-    //             );
-
-    //             this.toggle_entry(&entry_id, cx);
-    //         })
-    //     })
-    //     .detach_and_log_err(cx);
-    // }
-
     #[track_caller]
     #[cfg(any(test, feature = "test-support"))]
     pub fn assert_visual_entries(&self, expected: Vec<&str>, cx: &ViewContext<Self>) {

--- a/crates/debugger_ui/src/variable_list.rs
+++ b/crates/debugger_ui/src/variable_list.rs
@@ -1331,11 +1331,7 @@ impl VariableList {
                         "{} {}{}",
                         if is_expanded { "v" } else { ">" },
                         scope.name,
-                        if is_selected {
-                            format!("{}<== selected", INDENT)
-                        } else {
-                            "".to_string()
-                        }
+                        if is_selected { " <=== selected" } else { "" }
                     ));
                 }
                 VariableListEntry::SetVariableEditor { depth, state } => {
@@ -1343,11 +1339,7 @@ impl VariableList {
                         "{}  [EDITOR: {}]{}",
                         INDENT.repeat(*depth),
                         state.name,
-                        if is_selected {
-                            format!("{}<== selected", INDENT)
-                        } else {
-                            "".to_string()
-                        }
+                        if is_selected { " <=== selected" } else { "" }
                     ));
                 }
                 VariableListEntry::Variable {
@@ -1370,11 +1362,7 @@ impl VariableList {
                         INDENT.repeat(*depth),
                         if is_expanded { "v" } else { ">" },
                         variable.name,
-                        if is_selected {
-                            format!("{}<== selected", INDENT)
-                        } else {
-                            "".to_string()
-                        }
+                        if is_selected { " <=== selected" } else { "" }
                     ));
                 }
             };

--- a/crates/proto/proto/zed.proto
+++ b/crates/proto/proto/zed.proto
@@ -2510,8 +2510,9 @@ message DebuggerOpenEntryScope {
 }
 
 message DebuggerOpenEntryVariable {
-    string name = 1;
-    uint64 depth = 2;
+    uint64 scope_id = 1;
+    string name = 2;
+    uint64 depth = 3;
 }
 
 message DebuggerVariableListEntry {


### PR DESCRIPTION
https://github.com/user-attachments/assets/143d6fa8-2cf5-48e4-a3b6-4fb6b11178d7

### Info
This PR adds functionality for navigation through the variable list with your keyboard, this allows you to open/close scopes and variables. If the variable is not fetched, we try to fetch it, as we do when you click on a variable that has nested variables.

I also added a new test helper that can validate the visual structure of the scopes & variables of the current stack frame.
This makes it a bitter cleaner to write tests, and allows us to test more cases with less code.

---

### TODO
- [x] Add tests for opening/selecting scopes/variables
  - [x] Update test helper to contain selected state
- [x] Move selection state colors to helper method
- [x] Fix select variable/scope when you click on them, and show directly the select state
- [ ] Allow moving selection into SetValue editor