### PR TITLE
Update rust-embed version to fix CICD build error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -450,7 +450,7 @@ runtimelib = { version = "0.25.0", default-features = false, features = [
     "async-dispatcher-runtime",
 ] }
 rustc-demangle = "0.1.23"
-rust-embed = { version = "8.4", features = ["include-exclude"] }
+rust-embed = { version = "8.5", features = ["include-exclude"] }
 rustc-hash = "2.1.0"
 rustls = "0.21.12"
 rustls-native-certs = "0.8.0"


### PR DESCRIPTION
After spending too much time getting our branch to build with cargo build --workspace --all-features I tried updating rust-embed version from 8.4 -> 8.5 and that fixed the build error on my local machine!

I'm making this a PR so I can ensure CICD passes before I merge this in
