### PR TITLE
Fix Collab Module List Bug

### DIFF
--- a/crates/collab/src/tests/debug_panel_tests.rs
+++ b/crates/collab/src/tests/debug_panel_tests.rs
@@ -1092,3 +1092,228 @@ async fn test_updated_breakpoints_send_to_dap(
 
     shutdown_client.await.unwrap();
 }
+
+#[gpui::test]
+async fn test_module_list(cx_a: &mut TestAppContext, cx_b: &mut TestAppContext) {
+    let executor = cx_a.executor();
+    let mut server = TestServer::start(executor.clone()).await;
+    let client_a = server.create_client(cx_a, "user_a").await;
+    let client_b = server.create_client(cx_b, "user_b").await;
+
+    init_test(cx_a);
+    init_test(cx_b);
+
+    server
+        .create_room(&mut [(&client_a, cx_a), (&client_b, cx_b)])
+        .await;
+    let active_call_a = cx_a.read(ActiveCall::global);
+    let active_call_b = cx_b.read(ActiveCall::global);
+
+    let (project_a, _worktree_id) = client_a.build_local_project("/a", cx_a).await;
+    active_call_a
+        .update(cx_a, |call, cx| call.set_location(Some(&project_a), cx))
+        .await
+        .unwrap();
+
+    let project_id = active_call_a
+        .update(cx_a, |call, cx| call.share_project(project_a.clone(), cx))
+        .await
+        .unwrap();
+    let project_b = client_b.join_remote_project(project_id, cx_b).await;
+    active_call_b
+        .update(cx_b, |call, cx| call.set_location(Some(&project_b), cx))
+        .await
+        .unwrap();
+
+    let (workspace_a, cx_a) = client_a.build_workspace(&project_a, cx_a);
+    let (workspace_b, cx_b) = client_b.build_workspace(&project_b, cx_b);
+
+    add_debugger_panel(&workspace_a, cx_a).await;
+    add_debugger_panel(&workspace_b, cx_b).await;
+
+    let task = project_a.update(cx_a, |project, cx| {
+        project.dap_store().update(cx, |store, cx| {
+            store.start_debug_session(
+                dap::DebugAdapterConfig {
+                    label: "test config".into(),
+                    kind: dap::DebugAdapterKind::Fake,
+                    request: dap::DebugRequestType::Launch,
+                    program: None,
+                    cwd: None,
+                    initialize_args: None,
+                },
+                cx,
+            )
+        })
+    });
+
+    let (session, client) = task.await.unwrap();
+
+    let called_initialize = Arc::new(AtomicBool::new(false));
+
+    client
+        .on_request::<Initialize, _>({
+            let called_initialize = called_initialize.clone();
+            move |_, _| {
+                called_initialize.store(true, Ordering::SeqCst);
+                Ok(dap::Capabilities {
+                    supports_restart_frame: Some(true),
+                    supports_modules_request: Some(true),
+                    ..Default::default()
+                })
+            }
+        })
+        .await;
+
+    client.on_request::<Launch, _>(move |_, _| Ok(())).await;
+    client
+        .on_request::<StackTrace, _>(move |_, _| {
+            Ok(dap::StackTraceResponse {
+                stack_frames: Vec::default(),
+                total_frames: None,
+            })
+        })
+        .await;
+
+    let called_modules = Arc::new(AtomicBool::new(false));
+    let modules = vec![
+        dap::Module {
+            id: dap::ModuleId::Number(1),
+            name: "First Module".into(),
+            address_range: None,
+            date_time_stamp: None,
+            path: None,
+            symbol_file_path: None,
+            symbol_status: None,
+            version: None,
+            is_optimized: None,
+            is_user_code: None,
+        },
+        dap::Module {
+            id: dap::ModuleId::Number(2),
+            name: "Second Module".into(),
+            address_range: None,
+            date_time_stamp: None,
+            path: None,
+            symbol_file_path: None,
+            symbol_status: None,
+            version: None,
+            is_optimized: None,
+            is_user_code: None,
+        },
+    ];
+
+    client
+        .on_request::<dap::requests::Modules, _>({
+            let called_modules = called_modules.clone();
+            let modules = modules.clone();
+            move |_, _| unsafe {
+                static mut REQUEST_COUNT: i32 = 1;
+                assert_eq!(
+                    1, REQUEST_COUNT,
+                    "This request should only be called once from the host"
+                );
+                REQUEST_COUNT += 1;
+                called_modules.store(true, Ordering::SeqCst);
+
+                Ok(dap::ModulesResponse {
+                    modules: modules.clone(),
+                    total_modules: Some(2u64),
+                })
+            }
+        })
+        .await;
+
+    cx_a.run_until_parked();
+    cx_b.run_until_parked();
+
+    assert!(
+        called_initialize.load(std::sync::atomic::Ordering::SeqCst),
+        "Request Initialize must be called"
+    );
+
+    client
+        .fake_event(dap::messages::Events::Stopped(dap::StoppedEvent {
+            reason: dap::StoppedEventReason::Pause,
+            description: None,
+            thread_id: Some(1),
+            preserve_focus_hint: None,
+            text: None,
+            all_threads_stopped: None,
+            hit_breakpoint_ids: None,
+        }))
+        .await;
+
+    cx_a.run_until_parked();
+    cx_b.run_until_parked();
+
+    assert!(
+        called_modules.load(std::sync::atomic::Ordering::SeqCst),
+        "Request Modules must be called"
+    );
+
+    workspace_a.update(cx_a, |workspace, cx| {
+        let debug_panel = workspace.panel::<DebugPanel>(cx).unwrap();
+        let debug_panel_item = debug_panel
+            .update(cx, |this, cx| this.active_debug_panel_item(cx))
+            .unwrap();
+
+        debug_panel_item.update(cx, |item, cx| {
+            assert_eq!(
+                true,
+                item.capabilities(cx).supports_modules_request.unwrap(),
+                "Local supports modules request should be true"
+            );
+
+            let local_module_list = item.module_list().read(cx).modules();
+
+            assert_eq!(
+                2usize,
+                local_module_list.len(),
+                "Local module list should have two items in it"
+            );
+            assert_eq!(
+                &modules.clone(),
+                local_module_list,
+                "Local module list should match module list from response"
+            );
+        })
+    });
+
+    workspace_b.update(cx_b, |workspace, cx| {
+        let debug_panel = workspace.panel::<DebugPanel>(cx).unwrap();
+        let debug_panel_item = debug_panel
+            .update(cx, |this, cx| this.active_debug_panel_item(cx))
+            .unwrap();
+
+        debug_panel_item.update(cx, |item, cx| {
+            assert_eq!(
+                true,
+                item.capabilities(cx).supports_modules_request.unwrap(),
+                "Remote capabilities supports modules request should be true"
+            );
+            let remote_module_list = item.module_list().read(cx).modules();
+
+            assert_eq!(
+                2usize,
+                remote_module_list.len(),
+                "Remote module list should have two items in it"
+            );
+            assert_eq!(
+                &modules.clone(),
+                remote_module_list,
+                "Remote module list should match module list from response"
+            );
+        })
+    });
+
+    client.on_request::<Disconnect, _>(move |_, _| Ok(())).await;
+
+    let shutdown_client = project_a.update(cx_a, |project, cx| {
+        project.dap_store().update(cx, |dap_store, cx| {
+            dap_store.shutdown_session(&session.read(cx).id(), cx)
+        })
+    });
+
+    shutdown_client.await.unwrap();
+}

--- a/crates/debugger_ui/src/debugger_panel_item.rs
+++ b/crates/debugger_ui/src/debugger_panel_item.rs
@@ -129,6 +129,8 @@ impl DebugPanelItem {
             )
         });
 
+        cx.observe(&module_list, |_, _, cx| cx.notify()).detach();
+
         let _subscriptions = vec![
             cx.subscribe(&debug_panel, {
                 move |this: &mut Self, _, event: &DebugPanelEvent, cx| {
@@ -485,6 +487,11 @@ impl DebugPanelItem {
     #[cfg(any(test, feature = "test-support"))]
     pub fn console(&self) -> &View<Console> {
         &self.console
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn module_list(&self) -> &View<ModuleList> {
+        &self.module_list
     }
 
     #[cfg(any(test, feature = "test-support"))]

--- a/crates/debugger_ui/src/debugger_panel_item.rs
+++ b/crates/debugger_ui/src/debugger_panel_item.rs
@@ -200,7 +200,6 @@ impl DebugPanelItem {
 
     pub(crate) fn to_proto(&self, project_id: u64, cx: &AppContext) -> SetDebuggerPanelItem {
         let thread_state = Some(self.thread_state.read(cx).to_proto());
-        let module_list = Some(self.module_list.read(cx).to_proto());
         let variable_list = Some(self.variable_list.read(cx).to_proto());
         let stack_frame_list = Some(self.stack_frame_list.read(cx).to_proto());
 
@@ -210,7 +209,7 @@ impl DebugPanelItem {
             client_id: self.client_id.to_proto(),
             thread_id: self.thread_id,
             console: None,
-            module_list,
+            module_list: None,
             active_thread_item: self.active_thread_item.to_proto().into(),
             thread_state,
             variable_list,

--- a/crates/debugger_ui/src/module_list.rs
+++ b/crates/debugger_ui/src/module_list.rs
@@ -91,6 +91,15 @@ impl ModuleList {
 
         self.list.reset(self.modules.len());
         cx.notify();
+
+        let task = cx.spawn(|this, mut cx| async move {
+            this.update(&mut cx, |this, cx| {
+                this.propagate_updates(cx);
+            })
+            .log_err();
+        });
+
+        cx.background_executor().spawn(task).detach();
     }
 
     fn fetch_modules(&self, cx: &mut ViewContext<Self>) -> Task<Result<()>> {
@@ -106,21 +115,25 @@ impl ModuleList {
                 this.list.reset(this.modules.len());
                 cx.notify();
 
-                if let Some((client, id)) = this.dap_store.read(cx).downstream_client() {
-                    let request = UpdateDebugAdapter {
-                        session_id: this.session_id.to_proto(),
-                        client_id: this.client_id.to_proto(),
-                        project_id: *id,
-                        thread_id: None,
-                        variant: Some(rpc::proto::update_debug_adapter::Variant::Modules(
-                            this.to_proto(),
-                        )),
-                    };
-
-                    client.send(request).log_err();
-                }
+                this.propagate_updates(cx);
             })
         })
+    }
+
+    fn propagate_updates(&self, cx: &ViewContext<Self>) {
+        if let Some((client, id)) = self.dap_store.read(cx).downstream_client() {
+            let request = UpdateDebugAdapter {
+                session_id: self.session_id.to_proto(),
+                client_id: self.client_id.to_proto(),
+                project_id: *id,
+                thread_id: None,
+                variant: Some(rpc::proto::update_debug_adapter::Variant::Modules(
+                    self.to_proto(),
+                )),
+            };
+
+            client.send(request).log_err();
+        }
     }
 
     fn render_entry(&mut self, ix: usize, cx: &mut ViewContext<Self>) -> AnyElement {

--- a/crates/debugger_ui/src/module_list.rs
+++ b/crates/debugger_ui/src/module_list.rs
@@ -44,8 +44,9 @@ impl ModuleList {
             modules: Vec::default(),
         };
 
-        this.fetch_modules(cx).detach_and_log_err(cx);
-
+        if this.dap_store.read(cx).as_local().is_some() {
+            this.fetch_modules(cx).detach_and_log_err(cx);
+        }
         this
     }
 
@@ -154,5 +155,12 @@ impl Render for ModuleList {
             .size_full()
             .p_1()
             .child(list(self.list.clone()).size_full())
+    }
+}
+
+#[cfg(any(test, feature = "test-support"))]
+impl ModuleList {
+    pub fn modules(&self) -> &Vec<Module> {
+        &self.modules
     }
 }

--- a/crates/proto/proto/zed.proto
+++ b/crates/proto/proto/zed.proto
@@ -2743,7 +2743,7 @@ message SetDebuggerPanelItem {
     uint64 thread_id = 4;
     string session_name = 5;
     DebuggerConsole console = 6;
-    DebuggerModuleList module_list = 7;
+    optional DebuggerModuleList module_list = 7; // We only send this when it's supported and once per client
     DebuggerThreadItem active_thread_item = 8;
     DebuggerThreadState thread_state = 9;
     DebuggerVariableList variable_list = 10;


### PR DESCRIPTION
This PR fixes a module list bug where remote clients wouldn't have any modules in their module list when they hit their first breakpoint.

We now send module list changes whenever there is a module list update and don't send update messages in the `SetDebuggerPanelItem` proto message. This is because the module list usually doesn't change each time a user steps over, so sending the module list was wasting bandwidth. 

I also added a test for this as well! 
