### PR TITLE
Re-send breakpoints when source file has been changed

### DIFF
--- a/crates/collab/src/tests/debug_panel_tests.rs
+++ b/crates/collab/src/tests/debug_panel_tests.rs
@@ -944,6 +944,7 @@ async fn test_updated_breakpoints_send_to_dap(
                     }],
                     args.breakpoints.unwrap()
                 );
+                assert!(!args.source_modified.unwrap());
 
                 called_set_breakpoints.store(true, Ordering::SeqCst);
 
@@ -1007,6 +1008,7 @@ async fn test_updated_breakpoints_send_to_dap(
             move |_, args| {
                 assert_eq!("/a/test.txt", args.source.path.unwrap());
                 assert!(args.breakpoints.unwrap().is_empty());
+                assert!(!args.source_modified.unwrap());
 
                 called_set_breakpoints.store(true, Ordering::SeqCst);
 
@@ -1059,6 +1061,7 @@ async fn test_updated_breakpoints_send_to_dap(
                     ],
                     args.breakpoints.unwrap()
                 );
+                assert!(!args.source_modified.unwrap());
 
                 called_set_breakpoints.store(true, Ordering::SeqCst);
 

--- a/crates/debugger_ui/src/tests/debugger_panel.rs
+++ b/crates/debugger_ui/src/tests/debugger_panel.rs
@@ -2,13 +2,17 @@ use crate::*;
 use dap::{
     client::DebugAdapterClientId,
     requests::{
-        Continue, Disconnect, Initialize, Launch, Next, RunInTerminal, StackTrace, StartDebugging,
-        StepBack, StepIn, StepOut,
+        Continue, Disconnect, Initialize, Launch, Next, RunInTerminal, SetBreakpoints, StackTrace,
+        StartDebugging, StepBack, StepIn, StepOut,
     },
-    ErrorResponse, RunInTerminalRequestArguments, StartDebuggingRequestArguments,
+    ErrorResponse, RunInTerminalRequestArguments, SourceBreakpoint, StartDebuggingRequestArguments,
     StartDebuggingRequestArgumentsRequest,
 };
 use debugger_panel::ThreadStatus;
+use editor::{
+    actions::{self},
+    Editor, EditorMode, MultiBuffer,
+};
 use gpui::{BackgroundExecutor, TestAppContext, VisualTestContext};
 use project::{FakeFs, Project};
 use serde_json::json;
@@ -18,7 +22,7 @@ use std::sync::{
 };
 use terminal_view::{terminal_panel::TerminalPanel, TerminalView};
 use tests::{active_debug_panel_item, init_test, init_test_workspace};
-use workspace::dock::Panel;
+use workspace::{dock::Panel, Save};
 
 #[gpui::test]
 async fn test_basic_show_debug_panel(executor: BackgroundExecutor, cx: &mut TestAppContext) {
@@ -947,6 +951,202 @@ async fn test_debug_panel_item_thread_status_reset_on_failure(
                 });
         });
     }
+
+    let shutdown_session = project.update(cx, |project, cx| {
+        project.dap_store().update(cx, |dap_store, cx| {
+            dap_store.shutdown_session(&session.read(cx).id(), cx)
+        })
+    });
+
+    shutdown_session.await.unwrap();
+}
+
+#[gpui::test]
+async fn test_send_breakpoints_when_editor_has_been_saved(
+    executor: BackgroundExecutor,
+    cx: &mut TestAppContext,
+) {
+    init_test(cx);
+
+    let fs = FakeFs::new(executor.clone());
+
+    fs.insert_tree(
+        "/a",
+        json!({
+            "main.rs": "First line\nSecond line\nThird line\nFourth line",
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs, ["/a".as_ref()], cx).await;
+    let workspace = init_test_workspace(&project, cx).await;
+    let cx = &mut VisualTestContext::from_window(*workspace, cx);
+    let worktree_id = workspace
+        .update(cx, |workspace, cx| {
+            workspace.project().update(cx, |project, cx| {
+                project.worktrees(cx).next().unwrap().read(cx).id()
+            })
+        })
+        .unwrap();
+
+    let task = project.update(cx, |project, cx| {
+        project.dap_store().update(cx, |store, cx| {
+            store.start_debug_session(
+                task::DebugAdapterConfig {
+                    label: "test config".into(),
+                    kind: task::DebugAdapterKind::Fake,
+                    request: task::DebugRequestType::Launch,
+                    program: None,
+                    cwd: None,
+                    initialize_args: None,
+                },
+                cx,
+            )
+        })
+    });
+
+    let (session, client) = task.await.unwrap();
+
+    let buffer = project
+        .update(cx, |project, cx| {
+            project.open_buffer((worktree_id, "main.rs"), cx)
+        })
+        .await
+        .unwrap();
+
+    let window = cx.add_window(|cx| {
+        Editor::new(
+            EditorMode::Full,
+            MultiBuffer::build_from_buffer(buffer, cx),
+            Some(project.clone()),
+            true,
+            cx,
+        )
+    });
+
+    let cx = &mut VisualTestContext::from_window(*window, cx);
+
+    client
+        .on_request::<Initialize, _>(move |_, _| {
+            Ok(dap::Capabilities {
+                supports_step_back: Some(true),
+                ..Default::default()
+            })
+        })
+        .await;
+
+    client.on_request::<Launch, _>(move |_, _| Ok(())).await;
+
+    client
+        .on_request::<StackTrace, _>(move |_, _| {
+            Ok(dap::StackTraceResponse {
+                stack_frames: Vec::default(),
+                total_frames: None,
+            })
+        })
+        .await;
+
+    client.on_request::<Disconnect, _>(move |_, _| Ok(())).await;
+
+    client
+        .fake_event(dap::messages::Events::Stopped(dap::StoppedEvent {
+            reason: dap::StoppedEventReason::Pause,
+            description: None,
+            thread_id: Some(1),
+            preserve_focus_hint: None,
+            text: None,
+            all_threads_stopped: None,
+            hit_breakpoint_ids: None,
+        }))
+        .await;
+
+    let called_set_breakpoints = Arc::new(AtomicBool::new(false));
+    client
+        .on_request::<SetBreakpoints, _>({
+            let called_set_breakpoints = called_set_breakpoints.clone();
+            move |_, args| {
+                assert_eq!("/a/main.rs", args.source.path.unwrap());
+                assert_eq!(
+                    vec![SourceBreakpoint {
+                        line: 2,
+                        column: None,
+                        condition: None,
+                        hit_condition: None,
+                        log_message: None,
+                        mode: None
+                    }],
+                    args.breakpoints.unwrap()
+                );
+                assert!(!args.source_modified.unwrap());
+
+                called_set_breakpoints.store(true, Ordering::SeqCst);
+
+                Ok(dap::SetBreakpointsResponse {
+                    breakpoints: Vec::default(),
+                })
+            }
+        })
+        .await;
+
+    window
+        .update(cx, |editor, cx| {
+            editor.move_down(&actions::MoveDown, cx);
+            editor.toggle_breakpoint(&actions::ToggleBreakpoint, cx);
+        })
+        .unwrap();
+
+    cx.run_until_parked();
+
+    assert!(
+        called_set_breakpoints.load(std::sync::atomic::Ordering::SeqCst),
+        "SetBreakpoint request must be called"
+    );
+
+    let called_set_breakpoints = Arc::new(AtomicBool::new(false));
+    client
+        .on_request::<SetBreakpoints, _>({
+            let called_set_breakpoints = called_set_breakpoints.clone();
+            move |_, args| {
+                assert_eq!("/a/main.rs", args.source.path.unwrap());
+                assert_eq!(
+                    vec![SourceBreakpoint {
+                        line: 3,
+                        column: None,
+                        condition: None,
+                        hit_condition: None,
+                        log_message: None,
+                        mode: None
+                    }],
+                    args.breakpoints.unwrap()
+                );
+                assert!(args.source_modified.unwrap());
+
+                called_set_breakpoints.store(true, Ordering::SeqCst);
+
+                Ok(dap::SetBreakpointsResponse {
+                    breakpoints: Vec::default(),
+                })
+            }
+        })
+        .await;
+
+    window
+        .update(cx, |editor, cx| {
+            editor.move_up(&actions::MoveUp, cx);
+            editor.insert("new text", cx);
+
+            cx.dispatch_action(Box::new(Save {
+                save_intent: Some(workspace::SaveIntent::Save),
+            }));
+        })
+        .unwrap();
+
+    cx.run_until_parked();
+
+    assert!(
+        called_set_breakpoints.load(std::sync::atomic::Ordering::SeqCst),
+        "SetBreakpoint request must be called after editor is saved"
+    );
 
     let shutdown_session = project.update(cx, |project, cx| {
         project.dap_store().update(cx, |dap_store, cx| {

--- a/crates/debugger_ui/src/tests/debugger_panel.rs
+++ b/crates/debugger_ui/src/tests/debugger_panel.rs
@@ -1133,7 +1133,7 @@ async fn test_send_breakpoints_when_editor_has_been_saved(
     window
         .update(cx, |editor, cx| {
             editor.move_up(&actions::MoveUp, cx);
-            editor.insert("new text", cx);
+            editor.insert("new text\n", cx);
 
             cx.dispatch_action(Box::new(Save {
                 save_intent: Some(workspace::SaveIntent::Save),

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -12920,20 +12920,7 @@ impl Editor {
                 cx.notify();
             }
             multi_buffer::Event::DirtyChanged => cx.emit(EditorEvent::DirtyChanged),
-            multi_buffer::Event::Saved => {
-                cx.emit(EditorEvent::Saved);
-
-                if let Some(dap_store) = &self.dap_store {
-                    if let Some(project_path) = self.project_path(cx) {
-                        dap_store.update(cx, |_, cx| {
-                            cx.emit(DapStoreEvent::BreakpointsChanged {
-                                project_path,
-                                source_changed: true,
-                            });
-                        });
-                    }
-                }
-            }
+            multi_buffer::Event::Saved => cx.emit(EditorEvent::Saved),
             multi_buffer::Event::FileHandleChanged => {
                 cx.emit(EditorEvent::TitleChanged);
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -12921,8 +12921,8 @@ impl Editor {
             }
             multi_buffer::Event::DirtyChanged => cx.emit(EditorEvent::DirtyChanged),
             multi_buffer::Event::Saved => {
-                if let Some(project_path) = self.project_path(cx) {
-                    if let Some(dap_store) = &self.dap_store {
+                if let Some(dap_store) = &self.dap_store {
+                    if let Some(project_path) = self.project_path(cx) {
                         dap_store.update(cx, |_, cx| {
                             cx.emit(DapStoreEvent::BreakpointsChanged {
                                 project_path,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -12921,6 +12921,8 @@ impl Editor {
             }
             multi_buffer::Event::DirtyChanged => cx.emit(EditorEvent::DirtyChanged),
             multi_buffer::Event::Saved => {
+                cx.emit(EditorEvent::Saved);
+
                 if let Some(dap_store) = &self.dap_store {
                     if let Some(project_path) = self.project_path(cx) {
                         dap_store.update(cx, |_, cx| {
@@ -12931,12 +12933,22 @@ impl Editor {
                         });
                     }
                 }
+            }
+            multi_buffer::Event::FileHandleChanged => {
+                cx.emit(EditorEvent::TitleChanged);
 
-                cx.emit(EditorEvent::Saved);
+                if let Some(dap_store) = &self.dap_store {
+                    if let Some(project_path) = self.project_path(cx) {
+                        dap_store.update(cx, |_, cx| {
+                            cx.emit(DapStoreEvent::BreakpointsChanged {
+                                project_path,
+                                source_changed: true,
+                            });
+                        });
+                    }
+                }
             }
-            multi_buffer::Event::FileHandleChanged | multi_buffer::Event::Reloaded => {
-                cx.emit(EditorEvent::TitleChanged)
-            }
+            multi_buffer::Event::Reloaded => cx.emit(EditorEvent::TitleChanged),
             // multi_buffer::Event::DiffBaseChanged => {
             //     self.scrollbar_marker_state.dirty = true;
             //     cx.emit(EditorEvent::DiffBaseChanged);

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -1271,6 +1271,7 @@ impl Project {
                     abs_path,
                     source_breakpoints,
                     store.ignore_breakpoints(session_id, cx),
+                    false,
                     cx,
                 )
             }));
@@ -1403,6 +1404,7 @@ impl Project {
                             .map(|breakpoint| breakpoint.to_source_breakpoint(buffer))
                             .collect::<Vec<_>>(),
                         store.ignore_breakpoints(session_id, cx),
+                        false,
                         cx,
                     ),
                 );
@@ -2518,7 +2520,10 @@ impl Project {
                     message: message.clone(),
                 });
             }
-            DapStoreEvent::BreakpointsChanged(project_path) => {
+            DapStoreEvent::BreakpointsChanged {
+                project_path,
+                source_changed,
+            } => {
                 cx.notify(); // so the UI updates
 
                 let buffer_id = self
@@ -2544,6 +2549,7 @@ impl Project {
                             project_path,
                             absolute_path,
                             buffer.read(cx).snapshot(),
+                            *source_changed,
                             cx,
                         )
                         .detach_and_log_err(cx);


### PR DESCRIPTION
This PR should fix an issue, when you modify a file while you are debugging that the debugger not always sends the right row back for the current stack frame. So by re-sending the breakpoints when you saved the file, we should get the right row back for the current stack frame, so we also show the right current debug line after you modified the file.

TODO:
- [x] Add tests