### PR TITLE
Collab - Toggle Ignore Breakpoints

### DIFF
--- a/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
+++ b/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
@@ -474,6 +474,7 @@ CREATE TABLE IF NOT EXISTS "debug_clients" (
     project_id INTEGER NOT NULL,
     session_id BIGINT NOT NULL,
     capabilities INTEGER NOT NULL,
+    ignore_breakpoints BOOLEAN NOT NULL DEFAULT FALSE,
     PRIMARY KEY (id, project_id, session_id),
     FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE
 );

--- a/crates/collab/migrations/20250121181012_add_ignore_breakpoints.sql
+++ b/crates/collab/migrations/20250121181012_add_ignore_breakpoints.sql
@@ -1,0 +1,2 @@
+
+ALTER TABLE debug_clients ADD COLUMN ignore_breakpoints BOOLEAN NOT NULL DEFAULT FALSE;

--- a/crates/collab/src/db/queries/projects.rs
+++ b/crates/collab/src/db/queries/projects.rs
@@ -556,6 +556,40 @@ impl Database {
         .await
     }
 
+    pub async fn ignore_breakpoint_state(
+        &self,
+        connection_id: ConnectionId,
+        update: &proto::IgnoreBreakpointState,
+    ) -> Result<TransactionGuard<HashSet<ConnectionId>>> {
+        let project_id = ProjectId::from_proto(update.project_id);
+        self.project_transaction(project_id, |tx| async move {
+            let debug_clients = debug_clients::Entity::find()
+                .filter(
+                    Condition::all()
+                        .add(debug_clients::Column::ProjectId.eq(project_id))
+                        .add(debug_clients::Column::SessionId.eq(update.session_id)),
+                )
+                .all(&*tx)
+                .await?;
+
+            for debug_client in debug_clients {
+                debug_clients::Entity::update(debug_clients::ActiveModel {
+                    id: ActiveValue::Unchanged(debug_client.id),
+                    project_id: ActiveValue::Unchanged(debug_client.project_id),
+                    session_id: ActiveValue::Unchanged(debug_client.session_id),
+                    capabilities: ActiveValue::Unchanged(debug_client.capabilities),
+                    ignore_breakpoints: ActiveValue::Set(update.ignore),
+                })
+                .exec(&*tx)
+                .await?;
+            }
+
+            self.internal_project_connection_ids(project_id, connection_id, true, &tx)
+                .await
+        })
+        .await
+    }
+
     pub async fn update_debug_adapter(
         &self,
         connection_id: ConnectionId,

--- a/crates/collab/src/db/queries/projects.rs
+++ b/crates/collab/src/db/queries/projects.rs
@@ -647,6 +647,7 @@ impl Database {
                     project_id: ActiveValue::Set(project_id),
                     session_id: ActiveValue::Set(update.session_id as i64),
                     capabilities: ActiveValue::Set(0),
+                    ignore_breakpoints: ActiveValue::Set(false),
                 };
                 new_debug_client.insert(&*tx).await?;
             }
@@ -729,6 +730,7 @@ impl Database {
                     project_id: ActiveValue::Set(project_id),
                     session_id: ActiveValue::Set(update.session_id as i64),
                     capabilities: ActiveValue::Set(0),
+                    ignore_breakpoints: ActiveValue::Set(false),
                 };
                 debug_client = Some(new_debug_client.insert(&*tx).await?);
             }
@@ -742,6 +744,7 @@ impl Database {
                 project_id: ActiveValue::Unchanged(debug_client.project_id),
                 session_id: ActiveValue::Unchanged(debug_client.session_id),
                 capabilities: ActiveValue::Set(debug_client.capabilities),
+                ignore_breakpoints: ActiveValue::Set(debug_client.ignore_breakpoints),
             })
             .exec(&*tx)
             .await?;
@@ -1086,6 +1089,7 @@ impl Database {
 
         for (session_id, clients) in debug_sessions.into_iter() {
             let mut debug_clients = Vec::default();
+            let ignore_breakpoints = clients.iter().any(|debug| debug.ignore_breakpoints); // Temp solution until client -> session change
 
             for debug_client in clients.into_iter() {
                 let debug_panel_items = debug_client
@@ -1108,6 +1112,7 @@ impl Database {
                 project_id,
                 session_id: session_id as u64,
                 clients: debug_clients,
+                ignore_breakpoints,
             });
         }
 

--- a/crates/collab/src/db/tables/debug_clients.rs
+++ b/crates/collab/src/db/tables/debug_clients.rs
@@ -25,6 +25,7 @@ pub struct Model {
     pub session_id: i64,
     #[sea_orm(column_type = "Integer")]
     pub capabilities: i32,
+    pub ignore_breakpoints: bool,
 }
 
 impl Model {

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -446,7 +446,7 @@ impl Server {
                 broadcast_project_message_from_host::<proto::IgnoreBreakpointState>,
             )
             .add_message_handler(
-                broadcast_project_message_from_host::<proto::DebuggerSessionHasShutdown>,
+                broadcast_project_message_from_host::<proto::DebuggerSessionEnded>,
             );
 
         Arc::new(server)

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -438,6 +438,12 @@ impl Server {
             .add_request_handler(forward_mutating_project_request::<proto::VariablesRequest>)
             .add_message_handler(
                 broadcast_project_message_from_host::<proto::DapRestartStackFrameRequest>,
+            )
+            .add_message_handler(
+                broadcast_project_message_from_host::<proto::ToggleIgnoreBreakpoints>,
+            )
+            .add_message_handler(
+                broadcast_project_message_from_host::<proto::IgnoreBreakpointState>,
             );
 
         Arc::new(server)

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -444,6 +444,9 @@ impl Server {
             )
             .add_message_handler(
                 broadcast_project_message_from_host::<proto::IgnoreBreakpointState>,
+            )
+            .add_message_handler(
+                broadcast_project_message_from_host::<proto::DebuggerSessionHasShutdown>,
             );
 
         Arc::new(server)

--- a/crates/collab/src/tests/debug_panel_tests.rs
+++ b/crates/collab/src/tests/debug_panel_tests.rs
@@ -1850,3 +1850,381 @@ async fn test_variable_list(
 
     shutdown_client.await.unwrap();
 }
+
+#[gpui::test]
+async fn test_ignore_breakpoints(cx_a: &mut TestAppContext, cx_b: &mut TestAppContext) {
+    let executor = cx_a.executor();
+    let mut server = TestServer::start(executor.clone()).await;
+    let client_a = server.create_client(cx_a, "user_a").await;
+    let client_b = server.create_client(cx_b, "user_b").await;
+
+    client_a
+        .fs()
+        .insert_tree(
+            "/a",
+            json!({
+                "test.txt": "one\ntwo\nthree\nfour\nfive",
+            }),
+        )
+        .await;
+
+    init_test(cx_a);
+    init_test(cx_b);
+
+    server
+        .create_room(&mut [(&client_a, cx_a), (&client_b, cx_b)])
+        .await;
+    let active_call_a = cx_a.read(ActiveCall::global);
+    let active_call_b = cx_b.read(ActiveCall::global);
+
+    let (project_a, worktree_id) = client_a.build_local_project("/a", cx_a).await;
+    active_call_a
+        .update(cx_a, |call, cx| call.set_location(Some(&project_a), cx))
+        .await
+        .unwrap();
+
+    let project_path = ProjectPath {
+        worktree_id,
+        path: Arc::from(Path::new(&"test.txt")),
+    };
+
+    let project_id = active_call_a
+        .update(cx_a, |call, cx| call.share_project(project_a.clone(), cx))
+        .await
+        .unwrap();
+    let project_b = client_b.join_remote_project(project_id, cx_b).await;
+    active_call_b
+        .update(cx_b, |call, cx| call.set_location(Some(&project_b), cx))
+        .await
+        .unwrap();
+
+    let (workspace_a, cx_a) = client_a.build_workspace(&project_a, cx_a);
+    let (workspace_b, cx_b) = client_b.build_workspace(&project_b, cx_b);
+
+    add_debugger_panel(&workspace_a, cx_a).await;
+    add_debugger_panel(&workspace_b, cx_b).await;
+
+    let local_editor = workspace_a
+        .update(cx_a, |workspace, cx| {
+            workspace.open_path(project_path.clone(), None, true, cx)
+        })
+        .await
+        .unwrap()
+        .downcast::<Editor>()
+        .unwrap();
+
+    local_editor.update(cx_a, |editor, cx| {
+        editor.move_down(&editor::actions::MoveDown, cx);
+        editor.toggle_breakpoint(&editor::actions::ToggleBreakpoint, cx); // Line 2
+        editor.move_down(&editor::actions::MoveDown, cx);
+        editor.toggle_breakpoint(&editor::actions::ToggleBreakpoint, cx); // Line 3
+    });
+
+    cx_a.run_until_parked();
+    cx_b.run_until_parked();
+
+    let task = project_a.update(cx_a, |project, cx| {
+        project.dap_store().update(cx, |store, cx| {
+            store.start_debug_session(
+                dap::DebugAdapterConfig {
+                    label: "test config".into(),
+                    kind: dap::DebugAdapterKind::Fake,
+                    request: dap::DebugRequestType::Launch,
+                    program: None,
+                    cwd: None,
+                    initialize_args: None,
+                },
+                cx,
+            )
+        })
+    });
+
+    let (session, client) = task.await.unwrap();
+
+    client
+        .on_request::<Initialize, _>(move |_, _| {
+            Ok(dap::Capabilities {
+                supports_configuration_done_request: Some(true),
+                ..Default::default()
+            })
+        })
+        .await;
+
+    let called_set_breakpoints = Arc::new(AtomicBool::new(false));
+    client
+        .on_request::<SetBreakpoints, _>({
+            let called_set_breakpoints = called_set_breakpoints.clone();
+            move |_, args| {
+                assert_eq!("/a/test.txt", args.source.path.unwrap());
+
+                let mut actual_breakpoints = args.breakpoints.unwrap();
+                actual_breakpoints.sort_by_key(|b| b.line);
+
+                let expected_breakpoints = vec![
+                    SourceBreakpoint {
+                        line: 2,
+                        column: None,
+                        condition: None,
+                        hit_condition: None,
+                        log_message: None,
+                        mode: None,
+                    },
+                    SourceBreakpoint {
+                        line: 3,
+                        column: None,
+                        condition: None,
+                        hit_condition: None,
+                        log_message: None,
+                        mode: None,
+                    },
+                ];
+
+                assert_eq!(actual_breakpoints, expected_breakpoints);
+
+                called_set_breakpoints.store(true, Ordering::SeqCst);
+
+                Ok(dap::SetBreakpointsResponse {
+                    breakpoints: Vec::default(),
+                })
+            }
+        })
+        .await;
+
+    client.on_request::<Launch, _>(move |_, _| Ok(())).await;
+    client
+        .on_request::<StackTrace, _>(move |_, _| {
+            Ok(dap::StackTraceResponse {
+                stack_frames: Vec::default(),
+                total_frames: None,
+            })
+        })
+        .await;
+
+    client.on_request::<Disconnect, _>(move |_, _| Ok(())).await;
+
+    client
+        .fake_event(dap::messages::Events::Initialized(Some(
+            dap::Capabilities {
+                supports_configuration_done_request: Some(true),
+                ..Default::default()
+            },
+        )))
+        .await;
+
+    cx_a.run_until_parked();
+    cx_b.run_until_parked();
+
+    assert!(
+        called_set_breakpoints.load(std::sync::atomic::Ordering::SeqCst),
+        "SetBreakpoint request must be called when starting debug session"
+    );
+
+    client
+        .fake_event(dap::messages::Events::Stopped(dap::StoppedEvent {
+            reason: dap::StoppedEventReason::Pause,
+            description: None,
+            thread_id: Some(1),
+            preserve_focus_hint: None,
+            text: None,
+            all_threads_stopped: None,
+            hit_breakpoint_ids: None,
+        }))
+        .await;
+
+    cx_a.run_until_parked();
+    cx_b.run_until_parked();
+
+    called_set_breakpoints.store(false, Ordering::SeqCst);
+
+    client
+        .on_request::<SetBreakpoints, _>({
+            let called_set_breakpoints = called_set_breakpoints.clone();
+            move |_, args| {
+                assert_eq!("/a/test.txt", args.source.path.unwrap());
+                assert_eq!(args.breakpoints, Some(vec![]));
+
+                called_set_breakpoints.store(true, Ordering::SeqCst);
+
+                Ok(dap::SetBreakpointsResponse {
+                    breakpoints: Vec::default(),
+                })
+            }
+        })
+        .await;
+
+    let local_debug_item = workspace_a.update(cx_a, |workspace, cx| {
+        let debug_panel = workspace.panel::<DebugPanel>(cx).unwrap();
+        let active_debug_panel_item = debug_panel
+            .update(cx, |this, cx| this.active_debug_panel_item(cx))
+            .unwrap();
+
+        assert_eq!(
+            1,
+            debug_panel.update(cx, |this, cx| this.pane().unwrap().read(cx).items_len())
+        );
+        assert_eq!(client.id(), active_debug_panel_item.read(cx).client_id());
+        assert_eq!(1, active_debug_panel_item.read(cx).thread_id());
+
+        active_debug_panel_item
+    });
+
+    local_debug_item.update(cx_a, |item, cx| item.toggle_ignore_breakpoints(cx));
+
+    cx_a.run_until_parked();
+    cx_b.run_until_parked();
+
+    assert!(
+        called_set_breakpoints.load(std::sync::atomic::Ordering::SeqCst),
+        "SetBreakpoint request must be called to ignore breakpoints"
+    );
+
+    called_set_breakpoints.store(false, std::sync::atomic::Ordering::SeqCst);
+
+    client
+        .on_request::<SetBreakpoints, _>({
+            let called_set_breakpoints = called_set_breakpoints.clone();
+            move |_, _args| {
+                called_set_breakpoints.store(true, Ordering::SeqCst);
+
+                Ok(dap::SetBreakpointsResponse {
+                    breakpoints: Vec::default(),
+                })
+            }
+        })
+        .await;
+
+    let remote_editor = workspace_b
+        .update(cx_b, |workspace, cx| {
+            workspace.open_path(project_path.clone(), None, true, cx)
+        })
+        .await
+        .unwrap()
+        .downcast::<Editor>()
+        .unwrap();
+
+    remote_editor.update(cx_b, |editor, cx| {
+        editor.toggle_breakpoint(&editor::actions::ToggleBreakpoint, cx); // Line 1
+    });
+
+    cx_a.run_until_parked();
+    cx_b.run_until_parked();
+
+    assert!(
+        !called_set_breakpoints.load(std::sync::atomic::Ordering::SeqCst),
+        "SetBreakpoint request shouldn't be called when breakpoints are ignored"
+    );
+
+    let remote_debug_item = workspace_b.update(cx_b, |workspace, cx| {
+        let debug_panel = workspace.panel::<DebugPanel>(cx).unwrap();
+        let active_debug_panel_item = debug_panel
+            .update(cx, |this, cx| this.active_debug_panel_item(cx))
+            .unwrap();
+
+        assert_eq!(
+            1,
+            debug_panel.update(cx, |this, cx| this.pane().unwrap().read(cx).items_len())
+        );
+
+        let breakpoints_ignored = active_debug_panel_item.read(cx).are_breakpoints_ignored(cx);
+
+        assert_eq!(true, breakpoints_ignored);
+        assert_eq!(client.id(), active_debug_panel_item.read(cx).client_id());
+        assert_eq!(1, active_debug_panel_item.read(cx).thread_id());
+        active_debug_panel_item
+    });
+
+    client
+        .on_request::<SetBreakpoints, _>({
+            let called_set_breakpoints = called_set_breakpoints.clone();
+            move |_, args| {
+                assert_eq!("/a/test.txt", args.source.path.unwrap());
+
+                let mut actual_breakpoints = args.breakpoints.unwrap();
+                actual_breakpoints.sort_by_key(|b| b.line);
+
+                let expected_breakpoints = vec![
+                    SourceBreakpoint {
+                        line: 1,
+                        column: None,
+                        condition: None,
+                        hit_condition: None,
+                        log_message: None,
+                        mode: None,
+                    },
+                    SourceBreakpoint {
+                        line: 2,
+                        column: None,
+                        condition: None,
+                        hit_condition: None,
+                        log_message: None,
+                        mode: None,
+                    },
+                    SourceBreakpoint {
+                        line: 3,
+                        column: None,
+                        condition: None,
+                        hit_condition: None,
+                        log_message: None,
+                        mode: None,
+                    },
+                ];
+
+                assert_eq!(actual_breakpoints, expected_breakpoints);
+
+                called_set_breakpoints.store(true, Ordering::SeqCst);
+
+                Ok(dap::SetBreakpointsResponse {
+                    breakpoints: Vec::default(),
+                })
+            }
+        })
+        .await;
+
+    remote_debug_item.update(cx_b, |item, cx| {
+        item.toggle_ignore_breakpoints(cx);
+    });
+
+    cx_a.run_until_parked();
+    cx_b.run_until_parked();
+
+    assert!(
+        called_set_breakpoints.load(std::sync::atomic::Ordering::SeqCst),
+        "SetBreakpoint request should be called to update breakpoints"
+    );
+
+    client
+        .on_request::<SetBreakpoints, _>({
+            let called_set_breakpoints = called_set_breakpoints.clone();
+            move |_, args| {
+                assert_eq!("/a/test.txt", args.source.path.unwrap());
+                assert_eq!(args.breakpoints, Some(vec![]));
+
+                called_set_breakpoints.store(true, Ordering::SeqCst);
+
+                Ok(dap::SetBreakpointsResponse {
+                    breakpoints: Vec::default(),
+                })
+            }
+        })
+        .await;
+
+    local_debug_item.update(cx_a, |debug_panel_item, cx| {
+        assert_eq!(
+            true,
+            debug_panel_item.are_breakpoints_ignored(cx),
+            "Remote client set this to true"
+        );
+        debug_panel_item.toggle_ignore_breakpoints(cx);
+    });
+
+    cx_a.run_until_parked();
+    cx_b.run_until_parked();
+
+    let shutdown_client = project_a.update(cx_a, |project, cx| {
+        project.dap_store().update(cx, |dap_store, cx| {
+            dap_store.shutdown_session(&session.read(cx).id(), cx)
+        })
+    });
+
+    shutdown_client.await.unwrap();
+}

--- a/crates/dap/src/session.rs
+++ b/crates/dap/src/session.rs
@@ -19,54 +19,37 @@ impl DebugSessionId {
     }
 }
 
-pub struct DebugSession {
+pub enum DebugSession {
+    Local(LocalDebugSession),
+    Remote(RemoteDebugSession),
+}
+
+pub struct LocalDebugSession {
     id: DebugSessionId,
     ignore_breakpoints: bool,
     configuration: DebugAdapterConfig,
     clients: HashMap<DebugAdapterClientId, Arc<DebugAdapterClient>>,
 }
 
-impl DebugSession {
-    pub fn new(id: DebugSessionId, configuration: DebugAdapterConfig) -> Self {
-        Self {
-            id,
-            configuration,
-            ignore_breakpoints: false,
-            clients: HashMap::default(),
-        }
-    }
-
-    pub fn id(&self) -> DebugSessionId {
-        self.id
-    }
-
-    pub fn name(&self) -> String {
-        self.configuration.label.clone()
-    }
-
+impl LocalDebugSession {
     pub fn configuration(&self) -> &DebugAdapterConfig {
         &self.configuration
-    }
-
-    pub fn ignore_breakpoints(&self) -> bool {
-        self.ignore_breakpoints
-    }
-
-    pub fn set_ignore_breakpoints(&mut self, ignore: bool, cx: &mut ModelContext<Self>) {
-        self.ignore_breakpoints = ignore;
-        cx.notify();
     }
 
     pub fn update_configuration(
         &mut self,
         f: impl FnOnce(&mut DebugAdapterConfig),
-        cx: &mut ModelContext<Self>,
+        cx: &mut ModelContext<DebugSession>,
     ) {
         f(&mut self.configuration);
         cx.notify();
     }
 
-    pub fn add_client(&mut self, client: Arc<DebugAdapterClient>, cx: &mut ModelContext<Self>) {
+    pub fn add_client(
+        &mut self,
+        client: Arc<DebugAdapterClient>,
+        cx: &mut ModelContext<DebugSession>,
+    ) {
         self.clients.insert(client.id(), client);
         cx.notify();
     }
@@ -74,7 +57,7 @@ impl DebugSession {
     pub fn remove_client(
         &mut self,
         client_id: &DebugAdapterClientId,
-        cx: &mut ModelContext<Self>,
+        cx: &mut ModelContext<DebugSession>,
     ) -> Option<Arc<DebugAdapterClient>> {
         let client = self.clients.remove(client_id);
         cx.notify();
@@ -100,5 +83,77 @@ impl DebugSession {
 
     pub fn client_ids(&self) -> impl Iterator<Item = DebugAdapterClientId> + '_ {
         self.clients.keys().cloned()
+    }
+
+    pub fn id(&self) -> DebugSessionId {
+        self.id
+    }
+}
+
+pub struct RemoteDebugSession {
+    id: DebugSessionId,
+    ignore_breakpoints: bool,
+    label: String,
+}
+
+impl DebugSession {
+    pub fn new_local(id: DebugSessionId, configuration: DebugAdapterConfig) -> Self {
+        Self::Local(LocalDebugSession {
+            id,
+            ignore_breakpoints: false,
+            configuration,
+            clients: HashMap::default(),
+        })
+    }
+
+    pub fn as_local(&self) -> Option<&LocalDebugSession> {
+        match self {
+            DebugSession::Local(local) => Some(local),
+            _ => None,
+        }
+    }
+
+    pub fn as_local_mut(&mut self) -> Option<&mut LocalDebugSession> {
+        match self {
+            DebugSession::Local(local) => Some(local),
+            _ => None,
+        }
+    }
+
+    pub fn new_remote(id: DebugSessionId, label: String) -> Self {
+        Self::Remote(RemoteDebugSession {
+            id,
+            label: label.clone(),
+            ignore_breakpoints: false,
+        })
+    }
+
+    pub fn id(&self) -> DebugSessionId {
+        match self {
+            DebugSession::Local(local) => local.id,
+            DebugSession::Remote(remote) => remote.id,
+        }
+    }
+
+    pub fn name(&self) -> String {
+        match self {
+            DebugSession::Local(local) => local.configuration.label.clone(),
+            DebugSession::Remote(remote) => remote.label.clone(),
+        }
+    }
+
+    pub fn ignore_breakpoints(&self) -> bool {
+        match self {
+            DebugSession::Local(local) => local.ignore_breakpoints,
+            DebugSession::Remote(remote) => remote.ignore_breakpoints,
+        }
+    }
+
+    pub fn set_ignore_breakpoints(&mut self, ignore: bool, cx: &mut ModelContext<Self>) {
+        match self {
+            DebugSession::Local(local) => local.ignore_breakpoints = ignore,
+            DebugSession::Remote(remote) => remote.ignore_breakpoints = ignore,
+        }
+        cx.notify();
     }
 }

--- a/crates/dap/src/session.rs
+++ b/crates/dap/src/session.rs
@@ -120,11 +120,11 @@ impl DebugSession {
         }
     }
 
-    pub fn new_remote(id: DebugSessionId, label: String) -> Self {
+    pub fn new_remote(id: DebugSessionId, label: String, ignore_breakpoints: bool) -> Self {
         Self::Remote(RemoteDebugSession {
             id,
             label: label.clone(),
-            ignore_breakpoints: false,
+            ignore_breakpoints,
         })
     }
 

--- a/crates/debugger_tools/src/dap_log.rs
+++ b/crates/debugger_tools/src/dap_log.rs
@@ -580,25 +580,28 @@ impl DapLogView {
             .dap_store()
             .read(cx)
             .sessions()
-            .map(|session| DapMenuItem {
-                session_id: session.read(cx).id(),
-                session_name: session.read(cx).name(),
-                clients: {
-                    let mut clients = session
-                        .read(cx)
-                        .clients()
-                        .map(|client| DapMenuSubItem {
-                            client_id: client.id(),
-                            client_name: client.adapter_id(),
-                            has_adapter_logs: client.has_adapter_logs(),
-                            selected_entry: self
-                                .current_view
-                                .map_or(LogKind::Adapter, |(_, kind)| kind),
-                        })
-                        .collect::<Vec<_>>();
-                    clients.sort_by_key(|item| item.client_id.0);
-                    clients
-                },
+            .filter_map(|session| {
+                Some(DapMenuItem {
+                    session_id: session.read(cx).id(),
+                    session_name: session.read(cx).name(),
+                    clients: {
+                        let mut clients = session
+                            .read(cx)
+                            .as_local()?
+                            .clients()
+                            .map(|client| DapMenuSubItem {
+                                client_id: client.id(),
+                                client_name: client.adapter_id(),
+                                has_adapter_logs: client.has_adapter_logs(),
+                                selected_entry: self
+                                    .current_view
+                                    .map_or(LogKind::Adapter, |(_, kind)| kind),
+                            })
+                            .collect::<Vec<_>>();
+                        clients.sort_by_key(|item| item.client_id.0);
+                        clients
+                    },
+                })
             })
             .collect::<Vec<_>>();
         menu_items.sort_by_key(|item| item.session_id.0);

--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -1019,6 +1019,10 @@ impl DebugPanel {
                     )
                 });
 
+                self.dap_store.update(cx, |dap_store, cx| {
+                    dap_store.add_remote_session(session_id, None, cx);
+                });
+
                 pane.add_item(Box::new(debug_panel_item.clone()), true, true, None, cx);
                 debug_panel_item
             });

--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -292,6 +292,11 @@ impl DebugPanel {
         &self.message_queue
     }
 
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn dap_store(&self) -> Model<DapStore> {
+        self.dap_store.clone()
+    }
+
     pub fn active_debug_panel_item(
         &self,
         cx: &mut ViewContext<Self>,
@@ -1021,6 +1026,7 @@ impl DebugPanel {
 
                 self.dap_store.update(cx, |dap_store, cx| {
                     dap_store.add_remote_session(session_id, None, cx);
+                    dap_store.add_client_to_session(session_id, client_id);
                 });
 
                 pane.add_item(Box::new(debug_panel_item.clone()), true, true, None, cx);

--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -565,14 +565,19 @@ impl DebugPanel {
         client_id: &DebugAdapterClientId,
         cx: &mut ViewContext<Self>,
     ) {
-        let Some(session) = self.dap_store.read(cx).session_by_id(session_id) else {
+        let Some(session) = self
+            .dap_store
+            .read(cx)
+            .session_by_id(session_id)
+            .and_then(|session| session.read(cx).as_local())
+        else {
             return;
         };
 
         let session_id = *session_id;
         let client_id = *client_id;
         let workspace = self.workspace.clone();
-        let request_type = session.read(cx).configuration().request.clone();
+        let request_type = session.configuration().request.clone();
         cx.spawn(|this, mut cx| async move {
             let task = this.update(&mut cx, |this, cx| {
                 this.dap_store.update(cx, |store, cx| {

--- a/crates/debugger_ui/src/debugger_panel_item.rs
+++ b/crates/debugger_ui/src/debugger_panel_item.rs
@@ -506,6 +506,12 @@ impl DebugPanelItem {
         &self.thread_state
     }
 
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn are_breakpoints_ignored(&self, cx: &AppContext) -> bool {
+        self.dap_store
+            .read_with(cx, |dap, cx| dap.ignore_breakpoints(&self.session_id, cx))
+    }
+
     pub fn capabilities(&self, cx: &mut ViewContext<Self>) -> Capabilities {
         self.dap_store.read(cx).capabilities_by_id(&self.client_id)
     }

--- a/crates/debugger_ui/src/tests/debugger_panel.rs
+++ b/crates/debugger_ui/src/tests/debugger_panel.rs
@@ -707,7 +707,7 @@ async fn test_handle_start_debugging_reverse_request(
     cx.run_until_parked();
 
     project.update(cx, |_, cx| {
-        assert_eq!(2, session.read(cx).clients_len());
+        assert_eq!(2, session.read(cx).as_local().unwrap().clients_len());
     });
     assert!(
         send_response.load(std::sync::atomic::Ordering::SeqCst),
@@ -717,6 +717,8 @@ async fn test_handle_start_debugging_reverse_request(
     let second_client = project.update(cx, |_, cx| {
         session
             .read(cx)
+            .as_local()
+            .unwrap()
             .client_by_id(&DebugAdapterClientId(1))
             .unwrap()
     });

--- a/crates/project/src/dap_store.rs
+++ b/crates/project/src/dap_store.rs
@@ -460,7 +460,7 @@ impl DapStore {
 
     async fn handle_session_has_shutdown(
         this: Model<Self>,
-        envelope: TypedEnvelope<proto::DebuggerSessionHasShutdown>,
+        envelope: TypedEnvelope<proto::DebuggerSessionEnded>,
         mut cx: AsyncAppContext,
     ) -> Result<()> {
         this.update(&mut cx, |this, cx| {
@@ -1669,7 +1669,7 @@ impl DapStore {
 
         if let Some((downstream_client, project_id)) = self.downstream_client.as_ref() {
             downstream_client
-                .send(proto::DebuggerSessionHasShutdown {
+                .send(proto::DebuggerSessionEnded {
                     project_id: *project_id,
                     session_id: session_id.to_proto(),
                 })

--- a/crates/project/src/dap_store.rs
+++ b/crates/project/src/dap_store.rs
@@ -36,7 +36,9 @@ use dap_adapters::build_adapter;
 use fs::Fs;
 use futures::future::Shared;
 use futures::FutureExt;
-use gpui::{AsyncAppContext, Context, EventEmitter, Model, ModelContext, SharedString, Task};
+use gpui::{
+    AppContext, AsyncAppContext, Context, EventEmitter, Model, ModelContext, SharedString, Task,
+};
 use http_client::HttpClient;
 use language::{
     proto::{deserialize_anchor, serialize_anchor as serialize_text_anchor},
@@ -370,7 +372,7 @@ impl DapStore {
         &self.breakpoints
     }
 
-    pub fn ignore_breakpoints(&self, session_id: &DebugSessionId, cx: &ModelContext<Self>) -> bool {
+    pub fn ignore_breakpoints(&self, session_id: &DebugSessionId, cx: &AppContext) -> bool {
         self.session_by_id(session_id)
             .map(|session| session.read(cx).ignore_breakpoints())
             .unwrap_or_default()

--- a/crates/project/src/dap_store.rs
+++ b/crates/project/src/dap_store.rs
@@ -341,7 +341,7 @@ impl DapStore {
     ) -> Option<Model<DebugSession>> {
         match &self.mode {
             DapStoreMode::Local(local) => local.session_by_client_id(client_id),
-            DapStoreMode::Remote(remote) => dbg!(remote.session_by_client_id(client_id)),
+            DapStoreMode::Remote(remote) => remote.session_by_client_id(client_id),
         }
     }
 
@@ -444,13 +444,10 @@ impl DapStore {
         let client_id = DebugAdapterClientId::from_proto(envelope.payload.client_id);
 
         this.update(&mut cx, |this, cx| {
-            dbg!("In handle ignore breakpoint state");
             if let Some(session) = this.session_by_client_id(&client_id) {
                 session.update(cx, |session, cx| {
                     session.set_ignore_breakpoints(envelope.payload.ignore, cx)
                 });
-            } else {
-                dbg!("No session found for client ID: {}", client_id);
             }
         })?;
 
@@ -471,10 +468,9 @@ impl DapStore {
     }
 
     pub fn ignore_breakpoints(&self, session_id: &DebugSessionId, cx: &AppContext) -> bool {
-        dbg!(self
-            .session_by_id(session_id)
-            .map(|session| session.read(cx).ignore_breakpoints()))
-        .unwrap_or_default()
+        self.session_by_id(session_id)
+            .map(|session| session.read(cx).ignore_breakpoints())
+            .unwrap_or_default()
     }
 
     pub fn toggle_ignore_breakpoints(
@@ -838,7 +834,6 @@ impl DapStore {
         let mut adapter_args = client.adapter().request_args(&config);
         if let Some(args) = config.initialize_args.clone() {
             merge_json_value_into(args, &mut adapter_args);
-            dbg!(&adapter_args);
         }
 
         // TODO(debugger): GDB starts the debuggee program on launch instead of configurationDone

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -633,6 +633,8 @@ impl Project {
 
         client.add_model_request_handler(WorktreeStore::handle_rename_project_entry);
 
+        client.add_model_message_handler(Self::handle_toggle_ignore_breakpoints);
+
         WorktreeStore::init(&client);
         BufferStore::init(&client);
         LspStore::init(&client);
@@ -1385,6 +1387,26 @@ impl Project {
         result
     }
 
+    async fn handle_toggle_ignore_breakpoints(
+        this: Model<Self>,
+        envelope: TypedEnvelope<proto::ToggleIgnoreBreakpoints>,
+        mut cx: AsyncAppContext,
+    ) -> Result<()> {
+        this.update(&mut cx, |project, cx| {
+            // Only the host should handle this message because the host
+            // handles direct communication with the debugger servers.
+            if let Some((_, _)) = project.dap_store.read(cx).downstream_client() {
+                project
+                    .toggle_ignore_breakpoints(
+                        &DebugSessionId::from_proto(envelope.payload.session_id),
+                        &DebugAdapterClientId::from_proto(envelope.payload.client_id),
+                        cx,
+                    )
+                    .detach_and_log_err(cx);
+            }
+        })
+    }
+
     pub fn toggle_ignore_breakpoints(
         &self,
         session_id: &DebugSessionId,
@@ -1392,7 +1414,29 @@ impl Project {
         cx: &mut ModelContext<Self>,
     ) -> Task<Result<()>> {
         let tasks = self.dap_store.update(cx, |store, cx| {
+            if let Some((upstream_client, project_id)) = store.upstream_client() {
+                upstream_client
+                    .send(proto::ToggleIgnoreBreakpoints {
+                        session_id: session_id.to_proto(),
+                        client_id: client_id.to_proto(),
+                        project_id,
+                    })
+                    .log_err();
+
+                return Vec::new();
+            }
+
             store.toggle_ignore_breakpoints(session_id, cx);
+
+            if let Some((downstream_client, project_id)) = store.downstream_client() {
+                downstream_client
+                    .send(proto::IgnoreBreakpointState {
+                        client_id: client_id.to_proto(),
+                        project_id: *project_id,
+                        ignore: store.ignore_breakpoints(session_id, cx),
+                    })
+                    .log_err();
+            }
 
             let mut tasks = Vec::new();
 

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -1431,7 +1431,7 @@ impl Project {
             if let Some((downstream_client, project_id)) = store.downstream_client() {
                 downstream_client
                     .send(proto::IgnoreBreakpointState {
-                        client_id: client_id.to_proto(),
+                        session_id: session_id.to_proto(),
                         project_id: *project_id,
                         ignore: store.ignore_breakpoints(session_id, cx),
                     })

--- a/crates/proto/proto/zed.proto
+++ b/crates/proto/proto/zed.proto
@@ -334,7 +334,7 @@ message Envelope {
         DapRestartStackFrameRequest dap_restart_stack_frame_request = 313;
         IgnoreBreakpointState ignore_breakpoint_state = 314;
         ToggleIgnoreBreakpoints toggle_ignore_breakpoints = 315;
-        DebuggerSessionHasShutdown debugger_session_has_shutdown = 316; // current max
+        DebuggerSessionEnded debugger_session_ended = 316; // current max
     }
 
     reserved 87 to 88;
@@ -2474,7 +2474,7 @@ enum BreakpointKind {
     Log = 1;
 }
 
-message DebuggerSessionHasShutdown {
+message DebuggerSessionEnded {
     uint64 project_id = 1;
     uint64 session_id = 2;
 }

--- a/crates/proto/proto/zed.proto
+++ b/crates/proto/proto/zed.proto
@@ -2726,7 +2726,7 @@ message ToggleIgnoreBreakpoints {
 
 message IgnoreBreakpointState {
     uint64 project_id = 1;
-    uint64 client_id = 2;
+    uint64 session_id = 2;
     bool ignore = 3;
 }
 

--- a/crates/proto/proto/zed.proto
+++ b/crates/proto/proto/zed.proto
@@ -2476,7 +2476,8 @@ enum BreakpointKind {
 message DebuggerSession {
     uint64 session_id = 1;
     uint64 project_id = 2;
-    repeated DebugClient clients = 3;
+    bool ignore_breakpoints = 3;
+    repeated DebugClient clients = 4;
 }
 
 message DebugClient {

--- a/crates/proto/proto/zed.proto
+++ b/crates/proto/proto/zed.proto
@@ -333,7 +333,8 @@ message Envelope {
         DapVariables dap_variables = 312;
         DapRestartStackFrameRequest dap_restart_stack_frame_request = 313;
         IgnoreBreakpointState ignore_breakpoint_state = 314;
-        ToggleIgnoreBreakpoints toggle_ignore_breakpoints = 315; // current max
+        ToggleIgnoreBreakpoints toggle_ignore_breakpoints = 315;
+        DebuggerSessionHasShutdown debugger_session_has_shutdown = 316; // current max
     }
 
     reserved 87 to 88;
@@ -2471,6 +2472,11 @@ message RefreshLlmToken {}
 enum BreakpointKind {
     Standard = 0;
     Log = 1;
+}
+
+message DebuggerSessionHasShutdown {
+    uint64 project_id = 1;
+    uint64 session_id = 2;
 }
 
 message DebuggerSession {

--- a/crates/proto/proto/zed.proto
+++ b/crates/proto/proto/zed.proto
@@ -331,7 +331,9 @@ message Envelope {
         UpdateThreadStatus update_thread_status = 310;
         VariablesRequest variables_request = 311;
         DapVariables dap_variables = 312;
-        DapRestartStackFrameRequest dap_restart_stack_frame_request = 313; // current max
+        DapRestartStackFrameRequest dap_restart_stack_frame_request = 313;
+        IgnoreBreakpointState ignore_breakpoint_state = 314;
+        ToggleIgnoreBreakpoints toggle_ignore_breakpoints = 315; // current max
     }
 
     reserved 87 to 88;
@@ -2713,6 +2715,12 @@ message ToggleIgnoreBreakpoints {
     uint64 project_id = 1;
     uint64 client_id = 2;
     uint64 session_id = 3;
+}
+
+message IgnoreBreakpointState {
+    uint64 project_id = 1;
+    uint64 client_id = 2;
+    bool ignore = 3;
 }
 
 message DapNextRequest {

--- a/crates/proto/proto/zed.proto
+++ b/crates/proto/proto/zed.proto
@@ -2709,6 +2709,12 @@ message DapShutdownSession {
     optional uint64 session_id = 2; // Shutdown all sessions if this is None
 }
 
+message ToggleIgnoreBreakpoints {
+    uint64 project_id = 1;
+    uint64 client_id = 2;
+    uint64 session_id = 3;
+}
+
 message DapNextRequest {
     uint64 project_id = 1;
     uint64 client_id = 2;

--- a/crates/proto/src/proto.rs
+++ b/crates/proto/src/proto.rs
@@ -399,6 +399,7 @@ messages!(
     (DapVariables, Background),
     (IgnoreBreakpointState, Background),
     (ToggleIgnoreBreakpoints, Background),
+    (DebuggerSessionHasShutdown, Background),
 );
 
 request_messages!(
@@ -648,6 +649,7 @@ entity_messages!(
     VariablesRequest,
     IgnoreBreakpointState,
     ToggleIgnoreBreakpoints,
+    DebuggerSessionHasShutdown,
 );
 
 entity_messages!(

--- a/crates/proto/src/proto.rs
+++ b/crates/proto/src/proto.rs
@@ -397,6 +397,8 @@ messages!(
     (UsersResponse, Foreground),
     (VariablesRequest, Background),
     (DapVariables, Background),
+    (IgnoreBreakpointState, Background),
+    (ToggleIgnoreBreakpoints, Background),
 );
 
 request_messages!(
@@ -644,6 +646,8 @@ entity_messages!(
     DapShutdownSession,
     UpdateThreadStatus,
     VariablesRequest,
+    IgnoreBreakpointState,
+    ToggleIgnoreBreakpoints,
 );
 
 entity_messages!(

--- a/crates/proto/src/proto.rs
+++ b/crates/proto/src/proto.rs
@@ -399,7 +399,7 @@ messages!(
     (DapVariables, Background),
     (IgnoreBreakpointState, Background),
     (ToggleIgnoreBreakpoints, Background),
-    (DebuggerSessionHasShutdown, Background),
+    (DebuggerSessionEnded, Background),
 );
 
 request_messages!(
@@ -649,7 +649,7 @@ entity_messages!(
     VariablesRequest,
     IgnoreBreakpointState,
     ToggleIgnoreBreakpoints,
-    DebuggerSessionHasShutdown,
+    DebuggerSessionEnded,
 );
 
 entity_messages!(


### PR DESCRIPTION
This PR aims to allow toggle ignore breakpoints to work during collab debug session and to have the ignore breakpoint state sync for all users within a debug session

This PR is a bit messy right now because we're in the middle of refactoring debug session. Originally, debug sessions only belong to the local host, but remote clients need access to that information to render panel items correctly and handle some background processing. 

We're planning on cleaning up debug sessions to include a dap's capabilities, clean up the sync code, and have a debug session table instead of a debug client table in the collab db.
 

TODO:
- [x] Add collab unit test
- [x] Get toggle breakpoint working in collab
- [x] Sync Debug Session fields to remote clients
- [x] Create database migration to sync ignore breakpoint state for clients joining mid session

