### PR TITLE
Stack frame presentation hint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3600,7 +3600,7 @@ dependencies = [
 [[package]]
 name = "dap-types"
 version = "0.0.1"
-source = "git+https://github.com/zed-industries/dap-types?rev=a6376f02cf9c284c706bc919c21e7ce68ef1fb47#a6376f02cf9c284c706bc919c21e7ce68ef1fb47"
+source = "git+https://github.com/zed-industries/dap-types?rev=f44d7d8af3a8af3e0ca09933271bee17c99e15b1#f44d7d8af3a8af3e0ca09933271bee17c99e15b1"
 dependencies = [
  "schemars",
  "serde",

--- a/crates/dap/Cargo.toml
+++ b/crates/dap/Cargo.toml
@@ -25,7 +25,7 @@ async-tar.workspace = true
 async-trait.workspace = true
 client.workspace = true
 collections.workspace = true
-dap-types = { git = "https://github.com/zed-industries/dap-types", rev = "a6376f02cf9c284c706bc919c21e7ce68ef1fb47" }
+dap-types = { git = "https://github.com/zed-industries/dap-types", rev = "f44d7d8af3a8af3e0ca09933271bee17c99e15b1" }
 fs.workspace = true
 futures.workspace = true
 gpui.workspace = true


### PR DESCRIPTION
https://github.com/user-attachments/assets/ea8de7ef-4f40-471c-9489-b3fc86ba5268

------

This PR implements the first part of acting on the stack frame presentation hint. The first part is to add the collapsed stack frames feature, this will show stack frames that are ignored by an adapter with a placeholder that you could expand.

We decided to not implement this for collab, because we are going to implement the followable item soon.
So that will include that so we sync it better for host & clients. You can already toggle the collapsed stack frames on the guest side, tho, because we handle this on the client side.