### PR TITLE
Lazy load stack frame information (scopes & variables)

### DIFF
--- a/crates/debugger_ui/src/console.rs
+++ b/crates/debugger_ui/src/console.rs
@@ -108,7 +108,7 @@ impl Console {
         cx: &mut Context<Self>,
     ) {
         match event {
-            StackFrameListEvent::SelectedStackFrameChanged => cx.notify(),
+            StackFrameListEvent::SelectedStackFrameChanged(_) => cx.notify(),
             StackFrameListEvent::StackFramesUpdated => {}
         }
     }

--- a/crates/debugger_ui/src/debugger_panel_item.rs
+++ b/crates/debugger_ui/src/debugger_panel_item.rs
@@ -174,7 +174,7 @@ impl DebugPanelItem {
             cx.subscribe(
                 &stack_frame_list,
                 move |this: &mut Self, _, event: &StackFrameListEvent, cx| match event {
-                    StackFrameListEvent::SelectedStackFrameChanged
+                    StackFrameListEvent::SelectedStackFrameChanged(_)
                     | StackFrameListEvent::StackFramesUpdated => this.clear_highlights(cx),
                 },
             ),

--- a/crates/debugger_ui/src/stack_frame_list.rs
+++ b/crates/debugger_ui/src/stack_frame_list.rs
@@ -19,9 +19,11 @@ use workspace::Workspace;
 use crate::debugger_panel_item::DebugPanelItemEvent::Stopped;
 use crate::debugger_panel_item::{self, DebugPanelItem};
 
+pub type StackFrameId = u64;
+
 #[derive(Debug)]
 pub enum StackFrameListEvent {
-    SelectedStackFrameChanged,
+    SelectedStackFrameChanged(StackFrameId),
     StackFramesUpdated,
 }
 
@@ -31,12 +33,12 @@ pub struct StackFrameList {
     focus_handle: FocusHandle,
     session_id: DebugSessionId,
     dap_store: Entity<DapStore>,
-    current_stack_frame_id: u64,
     stack_frames: Vec<StackFrame>,
     entries: Vec<StackFrameEntry>,
     workspace: WeakEntity<Workspace>,
     client_id: DebugAdapterClientId,
     _subscriptions: Vec<Subscription>,
+    current_stack_frame_id: StackFrameId,
     fetch_stack_frames_task: Option<Task<Result<()>>>,
 }
 
@@ -244,7 +246,9 @@ impl StackFrameList {
     ) -> Task<Result<()>> {
         self.current_stack_frame_id = stack_frame.id;
 
-        cx.emit(StackFrameListEvent::SelectedStackFrameChanged);
+        cx.emit(StackFrameListEvent::SelectedStackFrameChanged(
+            stack_frame.id,
+        ));
         cx.notify();
 
         if let Some((client, id)) = self.dap_store.read(cx).downstream_client() {

--- a/crates/debugger_ui/src/tests/variable_list.rs
+++ b/crates/debugger_ui/src/tests/variable_list.rs
@@ -1117,3 +1117,587 @@ async fn test_keyboard_navigation(executor: BackgroundExecutor, cx: &mut TestApp
 
     shutdown_session.await.unwrap();
 }
+
+#[gpui::test]
+async fn test_it_only_fetches_scopes_and_variables_for_the_first_stack_frame(
+    executor: BackgroundExecutor,
+    cx: &mut TestAppContext,
+) {
+    init_test(cx);
+
+    let fs = FakeFs::new(executor.clone());
+
+    let test_file_content = r#"
+        import { SOME_VALUE } './module.js';
+
+        console.log(SOME_VALUE);
+    "#
+    .unindent();
+
+    let module_file_content = r#"
+        export SOME_VALUE = 'some value';
+    "#
+    .unindent();
+
+    fs.insert_tree(
+        "/project",
+        json!({
+           "src": {
+               "test.js": test_file_content,
+               "module.js": module_file_content,
+           }
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs, ["/project".as_ref()], cx).await;
+    let workspace = init_test_workspace(&project, cx).await;
+    let cx = &mut VisualTestContext::from_window(*workspace, cx);
+
+    let task = project.update(cx, |project, cx| {
+        project.start_debug_session(
+            task::DebugAdapterConfig {
+                label: "test config".into(),
+                kind: task::DebugAdapterKind::Fake,
+                request: task::DebugRequestType::Launch,
+                program: None,
+                cwd: None,
+                initialize_args: None,
+            },
+            cx,
+        )
+    });
+
+    let (session, client) = task.await.unwrap();
+
+    client
+        .on_request::<Initialize, _>(move |_, _| {
+            Ok(dap::Capabilities {
+                supports_step_back: Some(false),
+                ..Default::default()
+            })
+        })
+        .await;
+
+    client.on_request::<Launch, _>(move |_, _| Ok(())).await;
+
+    let stack_frames = vec![
+        StackFrame {
+            id: 1,
+            name: "Stack Frame 1".into(),
+            source: Some(dap::Source {
+                name: Some("test.js".into()),
+                path: Some("/project/src/test.js".into()),
+                source_reference: None,
+                presentation_hint: None,
+                origin: None,
+                sources: None,
+                adapter_data: None,
+                checksums: None,
+            }),
+            line: 3,
+            column: 1,
+            end_line: None,
+            end_column: None,
+            can_restart: None,
+            instruction_pointer_reference: None,
+            module_id: None,
+            presentation_hint: None,
+        },
+        StackFrame {
+            id: 2,
+            name: "Stack Frame 2".into(),
+            source: Some(dap::Source {
+                name: Some("module.js".into()),
+                path: Some("/project/src/module.js".into()),
+                source_reference: None,
+                presentation_hint: None,
+                origin: None,
+                sources: None,
+                adapter_data: None,
+                checksums: None,
+            }),
+            line: 1,
+            column: 1,
+            end_line: None,
+            end_column: None,
+            can_restart: None,
+            instruction_pointer_reference: None,
+            module_id: None,
+            presentation_hint: None,
+        },
+    ];
+
+    client
+        .on_request::<StackTrace, _>({
+            let stack_frames = Arc::new(stack_frames.clone());
+            move |_, args| {
+                assert_eq!(1, args.thread_id);
+
+                Ok(dap::StackTraceResponse {
+                    stack_frames: (*stack_frames).clone(),
+                    total_frames: None,
+                })
+            }
+        })
+        .await;
+
+    let frame_1_scopes = vec![Scope {
+        name: "Frame 1 Scope 1".into(),
+        presentation_hint: None,
+        variables_reference: 2,
+        named_variables: None,
+        indexed_variables: None,
+        expensive: false,
+        source: None,
+        line: None,
+        column: None,
+        end_line: None,
+        end_column: None,
+    }];
+
+    client
+        .on_request::<Scopes, _>({
+            let frame_1_scopes = Arc::new(frame_1_scopes.clone());
+            move |_, args| {
+                assert_eq!(1, args.frame_id);
+
+                Ok(dap::ScopesResponse {
+                    scopes: (*frame_1_scopes).clone(),
+                })
+            }
+        })
+        .await;
+
+    let frame_1_variables = vec![
+        Variable {
+            name: "variable1".into(),
+            value: "value 1".into(),
+            type_: None,
+            presentation_hint: None,
+            evaluate_name: None,
+            variables_reference: 0,
+            named_variables: None,
+            indexed_variables: None,
+            memory_reference: None,
+        },
+        Variable {
+            name: "variable2".into(),
+            value: "value 2".into(),
+            type_: None,
+            presentation_hint: None,
+            evaluate_name: None,
+            variables_reference: 0,
+            named_variables: None,
+            indexed_variables: None,
+            memory_reference: None,
+        },
+    ];
+
+    client
+        .on_request::<Variables, _>({
+            let frame_1_variables = Arc::new(frame_1_variables.clone());
+            move |_, args| {
+                assert_eq!(2, args.variables_reference);
+
+                Ok(dap::VariablesResponse {
+                    variables: (*frame_1_variables).clone(),
+                })
+            }
+        })
+        .await;
+
+    client.on_request::<Disconnect, _>(move |_, _| Ok(())).await;
+
+    client
+        .fake_event(dap::messages::Events::Stopped(dap::StoppedEvent {
+            reason: dap::StoppedEventReason::Pause,
+            description: None,
+            thread_id: Some(1),
+            preserve_focus_hint: None,
+            text: None,
+            all_threads_stopped: None,
+            hit_breakpoint_ids: None,
+        }))
+        .await;
+
+    cx.run_until_parked();
+
+    active_debug_panel_item(workspace, cx).update(cx, |debug_panel_item, cx| {
+        let stack_frame_list = debug_panel_item.stack_frame_list().read(cx);
+        let variable_list = debug_panel_item.variable_list().read(cx);
+
+        assert_eq!(1, stack_frame_list.current_stack_frame_id());
+        assert_eq!(stack_frames, stack_frame_list.stack_frames().clone());
+
+        assert_eq!(
+            frame_1_variables
+                .clone()
+                .into_iter()
+                .map(|variable| VariableContainer {
+                    container_reference: 2,
+                    variable,
+                    depth: 1
+                })
+                .collect::<Vec<_>>(),
+            variable_list.variables_by_stack_frame_id(1)
+        );
+        assert!(variable_list.variables_by_stack_frame_id(2).is_empty());
+    });
+
+    let shutdown_session = project.update(cx, |project, cx| {
+        project.dap_store().update(cx, |dap_store, cx| {
+            dap_store.shutdown_session(&session.read(cx).id(), cx)
+        })
+    });
+
+    shutdown_session.await.unwrap();
+}
+
+#[gpui::test]
+async fn test_it_fetches_scopes_variables_when_you_select_a_stack_frame(
+    executor: BackgroundExecutor,
+    cx: &mut TestAppContext,
+) {
+    init_test(cx);
+
+    let fs = FakeFs::new(executor.clone());
+
+    let test_file_content = r#"
+        import { SOME_VALUE } './module.js';
+
+        console.log(SOME_VALUE);
+    "#
+    .unindent();
+
+    let module_file_content = r#"
+        export SOME_VALUE = 'some value';
+    "#
+    .unindent();
+
+    fs.insert_tree(
+        "/project",
+        json!({
+           "src": {
+               "test.js": test_file_content,
+               "module.js": module_file_content,
+           }
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs, ["/project".as_ref()], cx).await;
+    let workspace = init_test_workspace(&project, cx).await;
+    let cx = &mut VisualTestContext::from_window(*workspace, cx);
+
+    let task = project.update(cx, |project, cx| {
+        project.start_debug_session(
+            task::DebugAdapterConfig {
+                label: "test config".into(),
+                kind: task::DebugAdapterKind::Fake,
+                request: task::DebugRequestType::Launch,
+                program: None,
+                cwd: None,
+                initialize_args: None,
+            },
+            cx,
+        )
+    });
+
+    let (session, client) = task.await.unwrap();
+
+    client
+        .on_request::<Initialize, _>(move |_, _| {
+            Ok(dap::Capabilities {
+                supports_step_back: Some(false),
+                ..Default::default()
+            })
+        })
+        .await;
+
+    client.on_request::<Launch, _>(move |_, _| Ok(())).await;
+
+    let stack_frames = vec![
+        StackFrame {
+            id: 1,
+            name: "Stack Frame 1".into(),
+            source: Some(dap::Source {
+                name: Some("test.js".into()),
+                path: Some("/project/src/test.js".into()),
+                source_reference: None,
+                presentation_hint: None,
+                origin: None,
+                sources: None,
+                adapter_data: None,
+                checksums: None,
+            }),
+            line: 3,
+            column: 1,
+            end_line: None,
+            end_column: None,
+            can_restart: None,
+            instruction_pointer_reference: None,
+            module_id: None,
+            presentation_hint: None,
+        },
+        StackFrame {
+            id: 2,
+            name: "Stack Frame 2".into(),
+            source: Some(dap::Source {
+                name: Some("module.js".into()),
+                path: Some("/project/src/module.js".into()),
+                source_reference: None,
+                presentation_hint: None,
+                origin: None,
+                sources: None,
+                adapter_data: None,
+                checksums: None,
+            }),
+            line: 1,
+            column: 1,
+            end_line: None,
+            end_column: None,
+            can_restart: None,
+            instruction_pointer_reference: None,
+            module_id: None,
+            presentation_hint: None,
+        },
+    ];
+
+    client
+        .on_request::<StackTrace, _>({
+            let stack_frames = Arc::new(stack_frames.clone());
+            move |_, args| {
+                assert_eq!(1, args.thread_id);
+
+                Ok(dap::StackTraceResponse {
+                    stack_frames: (*stack_frames).clone(),
+                    total_frames: None,
+                })
+            }
+        })
+        .await;
+
+    let frame_1_scopes = vec![Scope {
+        name: "Frame 1 Scope 1".into(),
+        presentation_hint: None,
+        variables_reference: 2,
+        named_variables: None,
+        indexed_variables: None,
+        expensive: false,
+        source: None,
+        line: None,
+        column: None,
+        end_line: None,
+        end_column: None,
+    }];
+
+    client
+        .on_request::<Scopes, _>({
+            let frame_1_scopes = Arc::new(frame_1_scopes.clone());
+            move |_, args| {
+                assert_eq!(1, args.frame_id);
+
+                Ok(dap::ScopesResponse {
+                    scopes: (*frame_1_scopes).clone(),
+                })
+            }
+        })
+        .await;
+
+    let frame_1_variables = vec![
+        Variable {
+            name: "variable1".into(),
+            value: "value 1".into(),
+            type_: None,
+            presentation_hint: None,
+            evaluate_name: None,
+            variables_reference: 0,
+            named_variables: None,
+            indexed_variables: None,
+            memory_reference: None,
+        },
+        Variable {
+            name: "variable2".into(),
+            value: "value 2".into(),
+            type_: None,
+            presentation_hint: None,
+            evaluate_name: None,
+            variables_reference: 0,
+            named_variables: None,
+            indexed_variables: None,
+            memory_reference: None,
+        },
+    ];
+
+    client
+        .on_request::<Variables, _>({
+            let frame_1_variables = Arc::new(frame_1_variables.clone());
+            move |_, args| {
+                assert_eq!(2, args.variables_reference);
+
+                Ok(dap::VariablesResponse {
+                    variables: (*frame_1_variables).clone(),
+                })
+            }
+        })
+        .await;
+
+    client.on_request::<Disconnect, _>(move |_, _| Ok(())).await;
+
+    client
+        .fake_event(dap::messages::Events::Stopped(dap::StoppedEvent {
+            reason: dap::StoppedEventReason::Pause,
+            description: None,
+            thread_id: Some(1),
+            preserve_focus_hint: None,
+            text: None,
+            all_threads_stopped: None,
+            hit_breakpoint_ids: None,
+        }))
+        .await;
+
+    cx.run_until_parked();
+
+    active_debug_panel_item(workspace, cx).update(cx, |debug_panel_item, cx| {
+        let stack_frame_list = debug_panel_item.stack_frame_list().read(cx);
+        let variable_list = debug_panel_item.variable_list().read(cx);
+
+        assert_eq!(1, stack_frame_list.current_stack_frame_id());
+        assert_eq!(stack_frames, stack_frame_list.stack_frames().clone());
+
+        assert_eq!(
+            frame_1_variables
+                .clone()
+                .into_iter()
+                .map(|variable| VariableContainer {
+                    container_reference: 2,
+                    variable,
+                    depth: 1
+                })
+                .collect::<Vec<_>>(),
+            variable_list.variables_by_stack_frame_id(1)
+        );
+        assert!(variable_list.variables_by_stack_frame_id(2).is_empty());
+    });
+
+    // add handlers for fetching the second stack frame's scopes and variables
+    // after the user clicked the stack frame
+
+    let frame_2_scopes = vec![Scope {
+        name: "Frame 2 Scope 1".into(),
+        presentation_hint: None,
+        variables_reference: 3,
+        named_variables: None,
+        indexed_variables: None,
+        expensive: false,
+        source: None,
+        line: None,
+        column: None,
+        end_line: None,
+        end_column: None,
+    }];
+
+    client
+        .on_request::<Scopes, _>({
+            let frame_2_scopes = Arc::new(frame_2_scopes.clone());
+            move |_, args| {
+                assert_eq!(2, args.frame_id);
+
+                Ok(dap::ScopesResponse {
+                    scopes: (*frame_2_scopes).clone(),
+                })
+            }
+        })
+        .await;
+
+    let frame_2_variables = vec![
+        Variable {
+            name: "variable3".into(),
+            value: "old value 1".into(),
+            type_: None,
+            presentation_hint: None,
+            evaluate_name: None,
+            variables_reference: 0,
+            named_variables: None,
+            indexed_variables: None,
+            memory_reference: None,
+        },
+        Variable {
+            name: "variable4".into(),
+            value: "old value 2".into(),
+            type_: None,
+            presentation_hint: None,
+            evaluate_name: None,
+            variables_reference: 0,
+            named_variables: None,
+            indexed_variables: None,
+            memory_reference: None,
+        },
+    ];
+
+    client
+        .on_request::<Variables, _>({
+            let frame_2_variables = Arc::new(frame_2_variables.clone());
+            move |_, args| {
+                assert_eq!(3, args.variables_reference);
+
+                Ok(dap::VariablesResponse {
+                    variables: (*frame_2_variables).clone(),
+                })
+            }
+        })
+        .await;
+
+    active_debug_panel_item(workspace, cx)
+        .update_in(cx, |debug_panel_item, window, cx| {
+            debug_panel_item
+                .stack_frame_list()
+                .update(cx, |stack_frame_list, cx| {
+                    stack_frame_list.select_stack_frame(&stack_frames[1], true, window, cx)
+                })
+        })
+        .await
+        .unwrap();
+
+    cx.run_until_parked();
+
+    active_debug_panel_item(workspace, cx).update(cx, |debug_panel_item, cx| {
+        let stack_frame_list = debug_panel_item.stack_frame_list().read(cx);
+        let variable_list = debug_panel_item.variable_list().read(cx);
+
+        assert_eq!(2, stack_frame_list.current_stack_frame_id());
+        assert_eq!(stack_frames, stack_frame_list.stack_frames().clone());
+
+        assert_eq!(
+            frame_1_variables
+                .into_iter()
+                .map(|variable| VariableContainer {
+                    container_reference: 2,
+                    variable,
+                    depth: 1
+                })
+                .collect::<Vec<_>>(),
+            variable_list.variables_by_stack_frame_id(1)
+        );
+        assert_eq!(
+            frame_2_variables
+                .into_iter()
+                .map(|variable| VariableContainer {
+                    container_reference: 3,
+                    variable,
+                    depth: 1
+                })
+                .collect::<Vec<_>>(),
+            variable_list.variables_by_stack_frame_id(2)
+        );
+    });
+
+    let shutdown_session = project.update(cx, |project, cx| {
+        project.dap_store().update(cx, |dap_store, cx| {
+            dap_store.shutdown_session(&session.read(cx).id(), cx)
+        })
+    });
+
+    shutdown_session.await.unwrap();
+}

--- a/crates/debugger_ui/src/variable_list.rs
+++ b/crates/debugger_ui/src/variable_list.rs
@@ -548,6 +548,7 @@ impl VariableList {
                 }
 
                 variable_list.build_entries(true, true, cx);
+                variable_list.send_update_proto_message(cx);
             })
         }));
     }

--- a/crates/debugger_ui/src/variable_list.rs
+++ b/crates/debugger_ui/src/variable_list.rs
@@ -1,4 +1,4 @@
-use crate::stack_frame_list::{StackFrameList, StackFrameListEvent};
+use crate::stack_frame_list::{StackFrameId, StackFrameList, StackFrameListEvent};
 use anyhow::{anyhow, Result};
 use dap::{
     client::DebugAdapterClientId, proto_conversions::ProtoConversion, session::DebugSessionId,
@@ -324,7 +324,6 @@ impl ScopeVariableIndex {
     }
 }
 
-type StackFrameId = u64;
 type ScopeId = u64;
 
 pub struct VariableList {
@@ -511,13 +510,46 @@ impl VariableList {
         cx: &mut Context<Self>,
     ) {
         match event {
-            StackFrameListEvent::SelectedStackFrameChanged => {
-                self.build_entries(true, true, cx);
+            StackFrameListEvent::SelectedStackFrameChanged(stack_frame_id) => {
+                self.handle_selected_stack_frame_changed(*stack_frame_id, cx);
             }
             StackFrameListEvent::StackFramesUpdated => {
                 self.fetch_variables(cx);
             }
         }
+    }
+
+    fn handle_selected_stack_frame_changed(
+        &mut self,
+        stack_frame_id: StackFrameId,
+        cx: &mut Context<Self>,
+    ) {
+        if self.scopes.contains_key(&stack_frame_id) {
+            return self.build_entries(true, true, cx);
+        }
+
+        self.fetch_variables_task = Some(cx.spawn(|this, mut cx| async move {
+            let task = this.update(&mut cx, |variable_list, cx| {
+                variable_list.fetch_variables_for_stack_frame(stack_frame_id, &Vec::default(), cx)
+            })?;
+
+            let (scopes, variables) = task.await?;
+
+            this.update(&mut cx, |variable_list, cx| {
+                variable_list.scopes.insert(stack_frame_id, scopes);
+
+                for (scope_id, variables) in variables.into_iter() {
+                    let mut variable_index = ScopeVariableIndex::new();
+                    variable_index.add_variables(scope_id, variables);
+
+                    variable_list
+                        .variables
+                        .insert((stack_frame_id, scope_id), variable_index);
+                }
+
+                variable_list.build_entries(true, true, cx);
+            })
+        }));
     }
 
     #[cfg(any(test, feature = "test-support"))]
@@ -930,8 +962,6 @@ impl VariableList {
         let stack_frames = self.stack_frame_list.read(cx).stack_frames().clone();
 
         self.fetch_variables_task = Some(cx.spawn(|this, mut cx| async move {
-            let mut tasks = Vec::with_capacity(stack_frames.len());
-
             let open_entries = this.update(&mut cx, |this, _| {
                 this.open_entries
                     .iter()
@@ -940,34 +970,27 @@ impl VariableList {
                     .collect::<Vec<_>>()
             })?;
 
-            for stack_frame in stack_frames.clone().into_iter() {
-                let task = this.update(&mut cx, |this, cx| {
-                    this.fetch_variables_for_stack_frame(stack_frame.id, &open_entries, cx)
-                });
+            let first_stack_frame = stack_frames
+                .first()
+                .ok_or(anyhow!("Expected to find a stackframe"))?;
 
-                tasks.push(
-                    cx.background_executor()
-                        .spawn(async move { anyhow::Ok((stack_frame.id, task?.await?)) }),
-                );
-            }
-
-            let results = futures::future::join_all(tasks).await;
+            let (scopes, variables) = this
+                .update(&mut cx, |this, cx| {
+                    this.fetch_variables_for_stack_frame(first_stack_frame.id, &open_entries, cx)
+                })?
+                .await?;
 
             this.update(&mut cx, |this, cx| {
                 let mut new_variables = BTreeMap::new();
                 let mut new_scopes = HashMap::new();
 
-                for (stack_frame_id, (scopes, variables)) in
-                    results.into_iter().filter_map(|result| result.ok())
-                {
-                    new_scopes.insert(stack_frame_id, scopes);
+                new_scopes.insert(first_stack_frame.id, scopes);
 
-                    for (scope_id, variables) in variables.into_iter() {
-                        let mut variable_index = ScopeVariableIndex::new();
-                        variable_index.add_variables(scope_id, variables);
+                for (scope_id, variables) in variables.into_iter() {
+                    let mut variable_index = ScopeVariableIndex::new();
+                    variable_index.add_variables(scope_id, variables);
 
-                        new_variables.insert((stack_frame_id, scope_id), variable_index);
-                    }
+                    new_variables.insert((first_stack_frame.id, scope_id), variable_index);
                 }
 
                 std::mem::swap(&mut this.variables, &mut new_variables);
@@ -976,23 +999,27 @@ impl VariableList {
                 this.entries.clear();
                 this.build_entries(true, true, cx);
 
-                if let Some((client, project_id)) = this.dap_store.read(cx).downstream_client() {
-                    let request = UpdateDebugAdapter {
-                        client_id: this.client_id.to_proto(),
-                        session_id: this.session_id.to_proto(),
-                        thread_id: Some(this.stack_frame_list.read(cx).thread_id()),
-                        project_id: *project_id,
-                        variant: Some(rpc::proto::update_debug_adapter::Variant::VariableList(
-                            this.to_proto(),
-                        )),
-                    };
-
-                    client.send(request).log_err();
-                };
+                this.send_update_proto_message(cx);
 
                 this.fetch_variables_task.take();
             })
         }));
+    }
+
+    fn send_update_proto_message(&self, cx: &mut Context<Self>) {
+        if let Some((client, project_id)) = self.dap_store.read(cx).downstream_client() {
+            let request = UpdateDebugAdapter {
+                client_id: self.client_id.to_proto(),
+                session_id: self.session_id.to_proto(),
+                thread_id: Some(self.stack_frame_list.read(cx).thread_id()),
+                project_id: *project_id,
+                variant: Some(rpc::proto::update_debug_adapter::Variant::VariableList(
+                    self.to_proto(),
+                )),
+            };
+
+            client.send(request).log_err();
+        };
     }
 
     fn deploy_variable_context_menu(


### PR DESCRIPTION
This PR changes when we fetch scopes & variables for a stack frame. Before this change, we would always fetch all the scopes & top level variables for all the stack frames. But this leads to a slow experience when you have a debug session that has a lot of stack frames. Not only that, but for example the JavaScript debugger allows you to visually skip stack frames, which why it does not make sense to fetch the scopes and variables for them only when you actually want to see them.

So this PR changes that, we now always only fetch the scopes & variables for the first stack frame and when a user selects a stack frame for the first time we will fetch the information after that we will only rebuild the visual entries everytime.