### PR TITLE
Show console output on remote debug clients

### DIFF
--- a/crates/collab/src/db/tables/debug_panel_items.rs
+++ b/crates/collab/src/db/tables/debug_panel_items.rs
@@ -129,6 +129,7 @@ impl Model {
                 let encoded = module_list.encode_to_vec();
                 self.module_list = encoded;
             }
+            proto::update_debug_adapter::Variant::OutputEvent(_) => {}
         }
 
         Ok(())

--- a/crates/debugger_ui/src/console.rs
+++ b/crates/debugger_ui/src/console.rs
@@ -2,7 +2,10 @@ use crate::{
     stack_frame_list::{StackFrameList, StackFrameListEvent},
     variable_list::VariableList,
 };
-use dap::{client::DebugAdapterClientId, OutputEvent, OutputEventGroup};
+use dap::{
+    client::DebugAdapterClientId, proto_conversions::ProtoConversion, session::DebugSessionId,
+    OutputEvent, OutputEventGroup,
+};
 use editor::{
     display_map::{Crease, CreaseId},
     Anchor, CompletionProvider, Editor, EditorElement, EditorStyle, FoldPlaceholder,
@@ -12,10 +15,12 @@ use gpui::{Context, Entity, Render, Subscription, Task, TextStyle, WeakEntity};
 use language::{Buffer, CodeLabel, LanguageServerId, ToOffsetUtf16};
 use menu::Confirm;
 use project::{dap_store::DapStore, Completion};
+use rpc::proto;
 use settings::Settings;
 use std::{cell::RefCell, collections::HashMap, rc::Rc, sync::Arc};
 use theme::ThemeSettings;
 use ui::{prelude::*, ButtonLike, Disclosure, ElevationIndex};
+use util::ResultExt;
 
 pub struct OutputGroup {
     pub start: Anchor,
@@ -29,6 +34,7 @@ pub struct Console {
     groups: Vec<OutputGroup>,
     console: Entity<Editor>,
     query_bar: Entity<Editor>,
+    session_id: DebugSessionId,
     dap_store: Entity<DapStore>,
     client_id: DebugAdapterClientId,
     _subscriptions: Vec<Subscription>,
@@ -39,6 +45,7 @@ pub struct Console {
 impl Console {
     pub fn new(
         stack_frame_list: &Entity<StackFrameList>,
+        session_id: &DebugSessionId,
         client_id: &DebugAdapterClientId,
         variable_list: Entity<VariableList>,
         dap_store: Entity<DapStore>,
@@ -87,6 +94,7 @@ impl Console {
             _subscriptions,
             client_id: *client_id,
             groups: Vec::default(),
+            session_id: *session_id,
             stack_frame_list: stack_frame_list.clone(),
         }
     }
@@ -114,6 +122,21 @@ impl Console {
     }
 
     pub fn add_message(&mut self, event: OutputEvent, window: &mut Window, cx: &mut Context<Self>) {
+        if let Some((client, project_id)) = self.dap_store.read(cx).downstream_client() {
+            client
+                .send(proto::UpdateDebugAdapter {
+                    project_id: *project_id,
+                    client_id: self.client_id.to_proto(),
+                    thread_id: None,
+                    session_id: self.session_id.to_proto(),
+                    variant: Some(proto::update_debug_adapter::Variant::OutputEvent(
+                        event.to_proto(),
+                    )),
+                })
+                .log_err();
+            return;
+        }
+
         self.console.update(cx, |console, cx| {
             let output = event.output.trim_end().to_string();
 

--- a/crates/debugger_ui/src/console.rs
+++ b/crates/debugger_ui/src/console.rs
@@ -109,6 +109,10 @@ impl Console {
         &self.query_bar
     }
 
+    fn is_local(&self, cx: &Context<Self>) -> bool {
+        self.dap_store.read(cx).as_local().is_some()
+    }
+
     fn handle_stack_frame_list_events(
         &mut self,
         _: Entity<StackFrameList>,
@@ -352,11 +356,10 @@ impl Render for Console {
             .on_action(cx.listener(Self::evaluate))
             .size_full()
             .child(self.render_console(cx))
-            .child(
-                div()
-                    .child(self.render_query_bar(cx))
-                    .pt(DynamicSpacing::Base04.rems(cx)),
-            )
+            .when(self.is_local(cx), |this| {
+                this.child(self.render_query_bar(cx))
+                    .pt(DynamicSpacing::Base04.rems(cx))
+            })
             .border_2()
     }
 }

--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -1009,7 +1009,7 @@ impl DebugPanel {
 
         if let Some((debug_panel_item, is_active_item)) = search {
             debug_panel_item.update(cx, |this, cx| {
-                this.update_adapter(update, cx);
+                this.update_adapter(update, window, cx);
 
                 if is_active_item {
                     this.go_to_current_stack_frame(window, cx);

--- a/crates/proto/proto/zed.proto
+++ b/crates/proto/proto/zed.proto
@@ -2809,8 +2809,7 @@ message DebuggerLoadedSourceList {
 }
 
 message DebuggerConsole {
-    // Editor console = 1;
-    // Editor query_bar = 2;
+    // repeated DapOutputEvent events = 1;
 }
 
 message DebuggerModuleList {
@@ -2844,6 +2843,7 @@ message UpdateDebugAdapter {
         DebuggerVariableList variable_list = 7;
         AddToVariableList add_to_variable_list = 8;
         DebuggerModuleList modules = 9;
+        DapOutputEvent output_event = 10;
     }
 }
 
@@ -2890,6 +2890,30 @@ message DapSource {
     repeated DapSource sources = 6;
     optional bytes adapter_data = 7;
     repeated DapChecksum checksums = 8;
+}
+
+enum DapOutputCategory {
+    ConsoleOutput = 0;
+    Important = 1;
+    Stdout = 2;
+    Stderr = 3;
+    Unknown = 4;
+}
+
+enum DapOutputEventGroup {
+    Start = 0;
+    StartCollapsed = 1;
+    End = 2;
+}
+
+message DapOutputEvent {
+    string output = 1;
+    optional DapOutputCategory category = 2;
+    optional uint64 variables_reference = 3;
+    optional DapOutputEventGroup group = 4;
+    optional DapSource source = 5;
+    optional uint32 line = 6;
+    optional uint32 column = 7;
 }
 
 enum DapChecksumAlgorithm {


### PR DESCRIPTION
This PR shows console output & removes the query bar for remote clients.

We don't show the query bar because it's currently impossible for remote clients to send evaluations requests from their console. We didn't implement that feature yet because of security consoles and will do so in the future with permissions. 

Co-authored-by: Remco Smits \<djsmits12@gmail.com\>