### PR TITLE
Make output console work again

### DIFF
--- a/crates/project/src/debugger/session.rs
+++ b/crates/project/src/debugger/session.rs
@@ -414,6 +414,8 @@ pub struct Session {
     ignore_breakpoints: bool,
     modules: Vec<dap::Module>,
     loaded_sources: Vec<dap::Source>,
+    last_processed_output: usize,
+    output: Vec<dap::OutputEvent>,
     threads: IndexMap<ThreadId, Thread>,
     requests: HashMap<RequestSlot, Shared<Task<Option<()>>>>,
     thread_states: ThreadStates,
@@ -550,6 +552,8 @@ impl Session {
                     capabilities,
                     thread_states: ThreadStates::default(),
                     ignore_breakpoints: false,
+                    last_processed_output: 0,
+                    output: Vec::default(),
                     requests: HashMap::default(),
                     modules: Vec::default(),
                     loaded_sources: Vec::default(),
@@ -578,6 +582,8 @@ impl Session {
             breakpoint_store,
             ignore_breakpoints,
             thread_states: ThreadStates::default(),
+            last_processed_output: 0,
+            output: Vec::default(),
             requests: HashMap::default(),
             modules: Vec::default(),
             loaded_sources: Vec::default(),
@@ -709,6 +715,18 @@ impl Session {
         })
     }
 
+    pub fn output(&self) -> Vec<dap::OutputEvent> {
+        self.output.iter().cloned().collect()
+    }
+
+    pub fn last_processed_output(&self) -> usize {
+        self.last_processed_output
+    }
+
+    pub fn set_last_processed_output(&mut self, last_processed_output: usize) {
+        self.last_processed_output = last_processed_output;
+    }
+
     fn handle_stopped_event(&mut self, event: StoppedEvent, cx: &mut Context<Self>) {
         // todo(debugger): We should query for all threads here if we don't get a thread id
         // maybe in both cases too?
@@ -757,7 +775,9 @@ impl Session {
                 }
                 self.invalidate_state(&ThreadsCommand.into());
             }
-            Events::Output(_event) => {}
+            Events::Output(event) => {
+                self.output.push(event);
+            }
             Events::Breakpoint(_) => {}
             Events::Module(_) => {
                 self.invalidate_state(&ModulesCommand.into());


### PR DESCRIPTION
This uses a last processed index for adding new messages to the editor, that we didn't add yet. By doing this, we can keep the folded/unfolded entries when we receive a new output event. So we don't unfold or fold an entry when the user changed this state, that would be a boomer.

<img width="670" alt="Screenshot 2025-02-21 at 15 04 29" src="https://github.com/user-attachments/assets/9e902575-fcf1-4f87-a08d-958425e8adc1" />

<img width="596" alt="Screenshot 2025-02-21 at 15 04 24" src="https://github.com/user-attachments/assets/72791b4b-3c6d-49df-9738-bbfac8a6a9b9" />